### PR TITLE
docs: add comprehensive README files

### DIFF
--- a/evento-macro/Cargo.toml
+++ b/evento-macro/Cargo.toml
@@ -7,6 +7,7 @@ publish = true
 description = "A collection of libraries and tools that help you build DDD, CQRS, and event sourcing."
 repository = "https://github.com/timayz/evento"
 documentation = "https://docs.rs/evento"
+readme = "README.md"
 
 [lib]
 proc-macro = true

--- a/evento-macro/README.md
+++ b/evento-macro/README.md
@@ -1,0 +1,142 @@
+# Evento Macros
+
+[![Crates.io](https://img.shields.io/crates/v/evento-macro.svg)](https://crates.io/crates/evento-macro)
+[![Documentation](https://docs.rs/evento-macro/badge.svg)](https://docs.rs/evento-macro)
+[![License](https://img.shields.io/crates/l/evento-macro.svg)](https://github.com/timayz/evento/blob/main/LICENSE)
+
+Procedural macros for the [Evento](https://crates.io/crates/evento) event sourcing framework.
+
+This crate provides macros that simplify building event-sourced applications by automatically generating boilerplate code for aggregators and event handlers.
+
+More information about this crate can be found in the [crate documentation][docs].
+
+## Usage
+
+This crate is typically used through the main `evento` crate with the `macro` feature enabled (which is on by default):
+
+```toml
+[dependencies]
+evento = "1.5"
+```
+
+Or explicitly:
+
+```toml
+[dependencies]
+evento = { version = "1.5", features = ["macro"] }
+```
+
+## Provided Macros
+
+### `#[evento::aggregator]`
+
+Automatically implements the `Aggregator` trait by generating event dispatching logic based on your handler methods.
+
+```rust
+use evento::{EventDetails, AggregatorName};
+use serde::{Deserialize, Serialize};
+use bincode::{Encode, Decode};
+
+#[derive(AggregatorName, Encode, Decode)]
+struct UserCreated {
+    name: String,
+    email: String,
+}
+
+#[derive(Default, Serialize, Deserialize, Encode, Decode, Clone, Debug)]
+struct User {
+    name: String,
+    email: String,
+}
+
+#[evento::aggregator]
+impl User {
+    async fn user_created(&mut self, event: EventDetails<UserCreated>) -> anyhow::Result<()> {
+        self.name = event.data.name;
+        self.email = event.data.email;
+        Ok(())
+    }
+}
+```
+
+The macro generates:
+- Implementation of `evento::Aggregator::aggregate` with event dispatching
+- Implementation of `evento::Aggregator::revision` based on a hash of handler methods
+- Implementation of `evento::AggregatorName` using the package name and struct name
+
+### `#[evento::handler(AggregateType)]`
+
+Creates an event handler for use with event subscriptions.
+
+```rust
+use evento::{Context, EventDetails, Executor};
+
+#[evento::handler(User)]
+async fn on_user_created<E: Executor>(
+    context: &Context<'_, E>,
+    event: EventDetails<UserCreated>,
+) -> anyhow::Result<()> {
+    println!("User created: {}", event.data.name);
+    // Trigger side effects, send notifications, update read models, etc.
+    Ok(())
+}
+
+// Use with subscription
+evento::subscribe("user-handlers")
+    .handler(on_user_created())
+    .run(&executor)
+    .await?;
+```
+
+The macro generates:
+- A struct implementing `evento::SubscribeHandler`
+- A constructor function returning an instance of that struct
+- Type-safe event filtering based on the event type
+
+### `#[derive(AggregatorName)]`
+
+Derives the `AggregatorName` trait which provides a name identifier for event types.
+
+```rust
+use evento::AggregatorName;
+use bincode::{Encode, Decode};
+
+#[derive(AggregatorName, Encode, Decode)]
+struct UserCreated {
+    name: String,
+    email: String,
+}
+
+assert_eq!(UserCreated::name(), "UserCreated");
+```
+
+## Requirements
+
+When using these macros, your types must implement the necessary traits:
+
+- **Aggregates** must implement: `Default`, `Send`, `Sync`, `Clone`, `Debug`, `bincode::Encode`, `bincode::Decode`
+- **Events** must implement: `bincode::Encode`, `bincode::Decode`
+- **Handler functions** must be `async` and return `anyhow::Result<()>`
+
+## Minimum Supported Rust Version
+
+Evento-macro's MSRV is 1.75.
+
+## Safety
+
+This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in 100% safe Rust.
+
+## Getting Help
+
+If you have questions or need help, please:
+
+- Check the [documentation][docs]
+- Look at the [examples] in the main evento repository
+- Open an issue on [GitHub](https://github.com/timayz/evento/issues)
+
+## License
+
+This project is licensed under the [Apache-2.0 license](LICENSE).
+
+[docs]: https://docs.rs/evento-macro
+[examples]: https://github.com/timayz/evento/tree/main/examples

--- a/evento/Cargo.toml
+++ b/evento/Cargo.toml
@@ -7,6 +7,7 @@ publish = true
 description = "A collection of libraries and tools that help you build DDD, CQRS, and event sourcing."
 repository = "https://github.com/timayz/evento"
 documentation = "https://docs.rs/evento"
+readme = "README.md"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/evento/README.md
+++ b/evento/README.md
@@ -1,0 +1,159 @@
+# Evento
+
+[![Crates.io](https://img.shields.io/crates/v/evento.svg)](https://crates.io/crates/evento)
+[![Documentation](https://docs.rs/evento/badge.svg)](https://docs.rs/evento)
+[![License](https://img.shields.io/crates/l/evento.svg)](https://github.com/timayz/evento/blob/main/LICENSE)
+
+A collection of libraries and tools that help you build DDD, CQRS, and event sourcing applications in Rust.
+
+More information about this crate can be found in the [crate documentation][docs].
+
+## Features
+
+- **Event Sourcing**: Store state changes as immutable events with complete audit trail
+- **CQRS Pattern**: Separate read and write models for scalable architectures
+- **SQL Database Support**: Built-in support for SQLite, PostgreSQL, and MySQL
+- **Event Handlers**: Async event processing with automatic retries
+- **Event Subscriptions**: Continuous event stream processing
+- **Event Streaming**: Real-time event streams (with `stream` feature)
+- **Snapshots**: Periodic state captures to optimize aggregate loading
+- **Database Migrations**: Automated schema management
+- **Macro Free API**: Clean, macro-free API (macros available optionally)
+- **Type Safety**: Fully typed events and aggregates with compile-time guarantees
+
+## Usage Example
+
+```rust
+use evento::{EventDetails, AggregatorName};
+use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
+
+// Define events
+#[derive(AggregatorName, Encode, Decode)]
+struct UserCreated {
+    name: String,
+    email: String,
+}
+
+#[derive(AggregatorName, Encode, Decode)]
+struct UserEmailChanged {
+    email: String,
+}
+
+// Define aggregate
+#[derive(Default, Serialize, Deserialize, Encode, Decode, Clone, Debug)]
+struct User {
+    name: String,
+    email: String,
+}
+
+// Implement event handlers on the aggregate
+#[evento::aggregator]
+impl User {
+    async fn user_created(&mut self, event: EventDetails<UserCreated>) -> anyhow::Result<()> {
+        self.name = event.data.name;
+        self.email = event.data.email;
+        Ok(())
+    }
+
+    async fn user_email_changed(&mut self, event: EventDetails<UserEmailChanged>) -> anyhow::Result<()> {
+        self.email = event.data.email;
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Setup SQLite executor
+    let pool = sqlx::SqlitePool::connect("sqlite:events.db").await?;
+    let executor: evento::Sqlite = pool.into();
+
+    // Create and save events
+    let user_id = evento::create::<User>()
+        .data(&UserCreated {
+            name: "John Doe".to_string(),
+            email: "john@example.com".to_string(),
+        })?
+        .metadata(&true)?
+        .commit(&executor)
+        .await?;
+
+    // Update user
+    evento::save::<User>(&user_id)
+        .data(&UserEmailChanged {
+            email: "newemail@example.com".to_string(),
+        })?
+        .metadata(&true)?
+        .commit(&executor)
+        .await?;
+
+    // Load aggregate from events
+    let user = evento::load::<User, _>(&executor, &user_id).await?;
+    println!("User: {:?}", user.item);
+
+    Ok(())
+}
+```
+
+## Event Handlers and Subscriptions
+
+```rust
+use evento::{Context, EventDetails, Executor};
+
+// Define a handler function
+#[evento::handler(User)]
+async fn on_user_created<E: Executor>(
+    context: &Context<'_, E>,
+    event: EventDetails<UserCreated>,
+) -> anyhow::Result<()> {
+    println!("User created: {} ({})", event.data.name, event.data.email);
+    // Trigger side effects, send emails, update read models, etc.
+    Ok(())
+}
+
+// Subscribe to events
+evento::subscribe("user-handlers")
+    .handler(on_user_created())
+    .run(&executor)
+    .await?;
+```
+
+## Feature Flags
+
+- **`macro`** _(enabled by default)_  Enable procedural macros for cleaner code
+- **`handler`** _(enabled by default)_  Enable event handlers with retry support
+- **`stream`**  Enable streaming support with `tokio-stream`
+- **`group`**  Enable event grouping functionality
+- **`sql`**  Enable all SQL database backends (SQLite, MySQL, PostgreSQL)
+- **`sqlite`**  SQLite support via sqlx
+- **`mysql`**  MySQL support via sqlx
+- **`postgres`**  PostgreSQL support via sqlx
+
+## Minimum Supported Rust Version
+
+Evento's MSRV is 1.75.
+
+## Safety
+
+This crate uses `#![forbid(unsafe_code)]` to ensure everything is implemented in 100% safe Rust.
+
+## Examples
+
+The [examples] directory contains sample applications demonstrating various features:
+
+- **todos** - A complete todo application with CQRS, demonstrating command/query separation and event handlers
+
+## Getting Help
+
+If you have questions or need help, please:
+
+- Check the [documentation][docs]
+- Look at the [examples]
+- Open an issue on [GitHub](https://github.com/timayz/evento/issues)
+
+## License
+
+This project is licensed under the [Apache-2.0 license](LICENSE).
+
+[docs]: https://docs.rs/evento
+[examples]: https://github.com/timayz/evento/tree/main/examples


### PR DESCRIPTION
## Summary

- Add comprehensive README documentation for both `evento` and `evento-macro` crates
- Follow modern Rust crate documentation standards (similar to axum and other popular crates)
- Include badges for crates.io, documentation, and license
- Provide complete usage examples and feature documentation

## Changes

### `evento` README
- Feature highlights (Event Sourcing, CQRS, SQL support, Event Handlers, etc.)
- Complete usage example showing aggregate creation and event handling
- Event subscription examples
- Feature flags documentation
- MSRV and safety information

### `evento-macro` README
- Documentation for all three procedural macros:
  - `#[evento::aggregator]`
  - `#[evento::handler]`
  - `#[derive(AggregatorName)]`
- Usage examples for each macro
- Requirements and type constraints
- Integration instructions

### Cargo.toml Updates
- Added `readme = "README.md"` to both crates so they appear on crates.io

## Test plan

- [x] READMEs render correctly in Markdown
- [x] Code examples are valid and match actual API
- [x] Links to documentation and examples are correct
- [x] Cargo.toml changes are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)