### PR TITLE
feat(executor): add default routing key on Evento

### DIFF
--- a/evento-core/src/executor.rs
+++ b/evento-core/src/executor.rs
@@ -120,6 +120,17 @@ impl Hash for ReadAggregator {
 /// - `acknowledge` - Update subscription cursor
 #[async_trait::async_trait]
 pub trait Executor: Send + Sync + 'static {
+    /// Default routing key applied to writes and inherited by subscriptions.
+    ///
+    /// Most backends return `None`; [`Evento`] overrides this to expose its
+    /// configured default. Used by `Evento::write` to fill in missing routing
+    /// keys, and by `SubscriptionBuilder::start` /
+    /// `ProjectionSubscription::start` to inherit a default when the user
+    /// has not called `.routing_key()` or `.all()`.
+    fn default_routing_key(&self) -> Option<&str> {
+        None
+    }
+
     /// Persists events atomically.
     ///
     /// Returns `WriteError::InvalidOriginalVersion` if version conflicts occur.
@@ -201,18 +212,35 @@ pub trait Executor: Send + Sync + 'static {
 /// // Use like any executor
 /// evento.write(events).await?;
 /// ```
-pub struct Evento(Arc<Box<dyn Executor>>);
+pub struct Evento {
+    inner: Arc<Box<dyn Executor>>,
+    default_routing_key: Option<String>,
+}
 
 impl Clone for Evento {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            inner: self.inner.clone(),
+            default_routing_key: self.default_routing_key.clone(),
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl Executor for Evento {
-    async fn write(&self, events: Vec<Event>) -> Result<(), WriteError> {
-        self.0.write(events).await
+    fn default_routing_key(&self) -> Option<&str> {
+        self.default_routing_key.as_deref()
+    }
+
+    async fn write(&self, mut events: Vec<Event>) -> Result<(), WriteError> {
+        if let Some(default) = self.default_routing_key.as_deref() {
+            for event in &mut events {
+                if event.routing_key.is_none() {
+                    event.routing_key = Some(default.to_owned());
+                }
+            }
+        }
+        self.inner.write(events).await
     }
 
     async fn read(
@@ -221,7 +249,7 @@ impl Executor for Evento {
         routing_key: Option<RoutingKey>,
         args: Args,
     ) -> anyhow::Result<ReadResult<Event>> {
-        self.0.read(aggregators, routing_key, args).await
+        self.inner.read(aggregators, routing_key, args).await
     }
 
     async fn latest_timestamp(
@@ -229,23 +257,23 @@ impl Executor for Evento {
         aggregators: Option<Vec<ReadAggregator>>,
         routing_key: Option<RoutingKey>,
     ) -> anyhow::Result<u64> {
-        self.0.latest_timestamp(aggregators, routing_key).await
+        self.inner.latest_timestamp(aggregators, routing_key).await
     }
 
     async fn get_subscriber_cursor(&self, key: String) -> anyhow::Result<Option<Value>> {
-        self.0.get_subscriber_cursor(key).await
+        self.inner.get_subscriber_cursor(key).await
     }
 
     async fn is_subscriber_running(&self, key: String, worker_id: Ulid) -> anyhow::Result<bool> {
-        self.0.is_subscriber_running(key, worker_id).await
+        self.inner.is_subscriber_running(key, worker_id).await
     }
 
     async fn upsert_subscriber(&self, key: String, worker_id: Ulid) -> anyhow::Result<()> {
-        self.0.upsert_subscriber(key, worker_id).await
+        self.inner.upsert_subscriber(key, worker_id).await
     }
 
     async fn acknowledge(&self, key: String, cursor: Value, lag: u64) -> anyhow::Result<()> {
-        self.0.acknowledge(key, cursor, lag).await
+        self.inner.acknowledge(key, cursor, lag).await
     }
 
     async fn get_snapshot(
@@ -254,7 +282,7 @@ impl Executor for Evento {
         aggregator_revision: String,
         id: String,
     ) -> anyhow::Result<Option<(Vec<u8>, Value)>> {
-        self.0
+        self.inner
             .get_snapshot(aggregator_type, aggregator_revision, id)
             .await
     }
@@ -267,20 +295,34 @@ impl Executor for Evento {
         data: Vec<u8>,
         cursor: Value,
     ) -> anyhow::Result<()> {
-        self.0
+        self.inner
             .save_snapshot(aggregator_type, aggregator_revision, id, data, cursor)
             .await
     }
 
     async fn delete_snapshot(&self, aggregator_type: String, id: String) -> anyhow::Result<()> {
-        self.0.delete_snapshot(aggregator_type, id).await
+        self.inner.delete_snapshot(aggregator_type, id).await
     }
 }
 
 impl Evento {
     /// Creates a new type-erased executor wrapper.
     pub fn new<E: Executor>(executor: E) -> Self {
-        Self(Arc::new(Box::new(executor)))
+        Self {
+            inner: Arc::new(Box::new(executor)),
+            default_routing_key: None,
+        }
+    }
+
+    /// Sets a default routing key applied to writes and inherited by
+    /// subscriptions built from this executor.
+    ///
+    /// Per-event/per-aggregator routing keys still take precedence on writes.
+    /// Subscriptions inherit this key only when the user has not called
+    /// `.routing_key()` or `.all()`.
+    pub fn default_routing_key(mut self, key: impl Into<String>) -> Self {
+        self.default_routing_key = Some(key.into());
+        self
     }
 }
 
@@ -322,6 +364,10 @@ impl EventoGroup {
 #[cfg(feature = "group")]
 #[async_trait::async_trait]
 impl Executor for EventoGroup {
+    fn default_routing_key(&self) -> Option<&str> {
+        self.first().default_routing_key()
+    }
+
     async fn write(&self, events: Vec<Event>) -> Result<(), WriteError> {
         self.first().write(events).await
     }
@@ -445,6 +491,10 @@ impl<R: Executor + Clone, W: Executor + Clone> Clone for Rw<R, W> {
 #[cfg(feature = "rw")]
 #[async_trait::async_trait]
 impl<R: Executor, W: Executor> Executor for Rw<R, W> {
+    fn default_routing_key(&self) -> Option<&str> {
+        self.w.default_routing_key()
+    }
+
     async fn write(&self, events: Vec<Event>) -> Result<(), WriteError> {
         self.w.write(events).await
     }

--- a/evento-core/src/projection.rs
+++ b/evento-core/src/projection.rs
@@ -414,7 +414,7 @@ impl<E: Executor, P: Snapshot<E> + Default + 'static> Projection<E, P> {
         ProjectionSubscription {
             projection: self,
             key: key.into(),
-            routing_key: RoutingKey::Value(None),
+            routing_key: None,
             chunk_size: 300,
             retry: Some(30),
             delay: None,
@@ -575,7 +575,7 @@ impl<E: Executor, P: Snapshot<E> + Default + 'static> LoadBuilder<E, P> {
 pub struct ProjectionSubscription<E: Executor, P: Default + 'static> {
     projection: Projection<E, P>,
     key: String,
-    routing_key: RoutingKey,
+    routing_key: Option<RoutingKey>,
     chunk_size: u16,
     retry: Option<u8>,
     delay: Option<Duration>,
@@ -588,14 +588,18 @@ where
     P: Snapshot<E> + Default + Send + Sync + 'static,
 {
     /// Filters events by routing key.
+    ///
+    /// Overrides any executor-level default.
     pub fn routing_key(mut self, v: impl Into<String>) -> Self {
-        self.routing_key = RoutingKey::Value(Some(v.into()));
+        self.routing_key = Some(RoutingKey::Value(Some(v.into())));
         self
     }
 
     /// Processes all events regardless of routing key.
+    ///
+    /// Overrides any executor-level default.
     pub fn all(mut self) -> Self {
-        self.routing_key = RoutingKey::All;
+        self.routing_key = Some(RoutingKey::All);
         self
     }
 
@@ -666,9 +670,9 @@ where
 
         let mut builder: SubscriptionBuilder<E> = SubscriptionBuilder::new(key);
         builder = match routing_key {
-            RoutingKey::All => builder.all(),
-            RoutingKey::Value(Some(v)) => builder.routing_key(v),
-            RoutingKey::Value(None) => builder,
+            Some(RoutingKey::All) => builder.all(),
+            Some(RoutingKey::Value(Some(v))) => builder.routing_key(v),
+            Some(RoutingKey::Value(None)) | None => builder,
         };
         builder = builder.chunk_size(chunk_size);
         builder = match retry {

--- a/evento-core/src/subscription.rs
+++ b/evento-core/src/subscription.rs
@@ -143,7 +143,7 @@ pub struct SubscriptionBuilder<E: Executor> {
     key: String,
     handlers: HashMap<String, Box<dyn Handler<E>>>,
     context: context::RwContext,
-    routing_key: RoutingKey,
+    routing_key: Option<RoutingKey>,
     delay: Option<Duration>,
     chunk_size: u16,
     is_accept_failure: bool,
@@ -167,7 +167,7 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
             retry: Some(30),
             chunk_size: 300,
             is_accept_failure: false,
-            routing_key: RoutingKey::Value(None),
+            routing_key: None,
             aggregators: Default::default(),
             shutdown_rx: None,
         }
@@ -246,8 +246,9 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
     /// Filters events by routing key.
     ///
     /// Only events with the matching routing key will be processed.
+    /// Overrides any executor-level default.
     pub fn routing_key(mut self, v: impl Into<String>) -> Self {
-        self.routing_key = RoutingKey::Value(Some(v.into()));
+        self.routing_key = Some(RoutingKey::Value(Some(v.into())));
 
         self
     }
@@ -262,8 +263,10 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
     }
 
     /// Processes all events regardless of routing key.
+    ///
+    /// Overrides any executor-level default.
     pub fn all(mut self) -> Self {
-        self.routing_key = RoutingKey::All;
+        self.routing_key = Some(RoutingKey::All);
 
         self
     }
@@ -301,11 +304,30 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
     }
 
     fn key(&self) -> String {
-        if let RoutingKey::Value(Some(ref key)) = self.routing_key {
+        if let Some(RoutingKey::Value(Some(ref key))) = self.routing_key {
             return format!("{key}.{}", self.key);
         }
 
         self.key.to_owned()
+    }
+
+    /// Resolves an unset routing key from the executor's default.
+    ///
+    /// Called once at the top of `start()` / `execute()` before any other
+    /// method reads `self.routing_key`. After this, `routing_key` is always
+    /// `Some(_)`.
+    fn resolve_routing_key(&mut self, executor: &E) {
+        if self.routing_key.is_some() {
+            return;
+        }
+        self.routing_key = Some(match executor.default_routing_key() {
+            Some(k) => RoutingKey::Value(Some(k.to_owned())),
+            None => RoutingKey::Value(None),
+        });
+    }
+
+    fn effective_routing_key(&self) -> RoutingKey {
+        self.routing_key.clone().unwrap_or(RoutingKey::Value(None))
     }
 
     #[tracing::instrument(
@@ -342,7 +364,7 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
             let res = executor
                 .read(
                     Some(aggregators.to_vec()),
-                    Some(self.routing_key.to_owned()),
+                    Some(self.effective_routing_key()),
                     Args::forward(self.chunk_size, cursor),
                 )
                 .await?;
@@ -354,7 +376,7 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
             let timestamp = executor
                 .latest_timestamp(
                     Some(aggregators.to_vec()),
-                    Some(self.routing_key.to_owned()),
+                    Some(self.effective_routing_key()),
                 )
                 .await?;
 
@@ -435,6 +457,7 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
     where
         E: Clone,
     {
+        self.resolve_routing_key(executor);
         let executor = executor.clone();
         let id = Ulid::new();
         let subscription_id = id;
@@ -532,7 +555,8 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
         aggregator_id = tracing::field::Empty,
         event = tracing::field::Empty,
     ))]
-    pub async fn execute(&self, executor: &E) -> anyhow::Result<()> {
+    pub async fn execute(&mut self, executor: &E) -> anyhow::Result<()> {
+        self.resolve_routing_key(executor);
         let id = Ulid::new();
 
         executor

--- a/evento-fjall/tests/fjall.rs
+++ b/evento-fjall/tests/fjall.rs
@@ -84,6 +84,12 @@ async fn fjall_subscribe_default_multiple_aggregator() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn fjall_subscribe_default_routing_key() -> anyhow::Result<()> {
+    let (executor, _temp_dir) = create_fjall_executor("subscribe_default_routing_key")?;
+    evento_test::subscribe_default_routing_key(&executor).await
+}
+
+#[tokio::test]
 async fn fjall_all_commands() -> anyhow::Result<()> {
     let (executor, _temp_dir) = create_fjall_executor("all_commands")?;
     evento_test::all_commands(&executor).await

--- a/evento-sql/tests/sqlite.rs
+++ b/evento-sql/tests/sqlite.rs
@@ -97,6 +97,13 @@ async fn sqlite_subscribe_default_multiple_aggregator() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn sqlite_subscribe_default_routing_key() -> anyhow::Result<()> {
+    let pool = create_sqlite_pool("subscribe_default_routing_key").await?;
+
+    evento_test::subscribe_default_routing_key::<Sql<sqlx::Sqlite>>(&pool.into()).await
+}
+
+#[tokio::test]
 async fn sqlite_all_commands() -> anyhow::Result<()> {
     let pool = create_sqlite_pool("all_commands").await?;
 

--- a/evento-test/src/lib.rs
+++ b/evento-test/src/lib.rs
@@ -779,6 +779,95 @@ pub async fn subscribe_default<E: Executor + Clone>(executor: &E) -> anyhow::Res
     Ok(())
 }
 
+pub async fn subscribe_default_routing_key<E: Executor + Clone>(
+    executor: &E,
+) -> anyhow::Result<()> {
+    // Wrap the underlying executor in an Evento with a global default routing key.
+    let evento = evento::Evento::new(executor.clone()).default_routing_key("default-region");
+    let cmd = bank::Command(evento.clone());
+
+    // (1) Writing without an explicit routing key should pick up the executor default.
+    let default_account_id = cmd
+        .open_account(OpenAccount {
+            owner_id: "owner_default".to_owned(),
+            owner_name: "Default User".to_owned(),
+            account_type: AccountType::Checking,
+            currency: "USD".to_owned(),
+            initial_balance: 1000,
+        })
+        .await?;
+
+    // (2) Writing with an explicit routing key should still win over the default.
+    let other_account_id = cmd
+        .open_account_with_routing(
+            OpenAccount {
+                owner_id: "owner_other".to_owned(),
+                owner_name: "Other User".to_owned(),
+                account_type: AccountType::Checking,
+                currency: "EUR".to_owned(),
+                initial_balance: 2000,
+            },
+            "other-region",
+        )
+        .await?;
+
+    assert_eq!(
+        last_routing_key(&evento, &default_account_id).await?,
+        Some("default-region".to_owned()),
+        "events without explicit routing key should inherit the executor default"
+    );
+    assert_eq!(
+        last_routing_key(&evento, &other_account_id).await?,
+        Some("other-region".to_owned()),
+        "explicit per-aggregator routing key must win over the executor default"
+    );
+
+    // Drop any state these accounts left behind so we can observe the subscription pass.
+    {
+        let mut rows = simple::ROWS.write().unwrap();
+        rows.remove(&default_account_id);
+        rows.remove(&other_account_id);
+    }
+
+    // (3) A subscription with neither .routing_key() nor .all() should inherit the
+    // executor default when started against the Evento wrapper.
+    simple::subscription().unretry_execute(&evento).await?;
+
+    {
+        let rows = simple::ROWS.read().unwrap();
+        assert!(
+            rows.contains_key(&default_account_id),
+            "default-region account should be processed by the inherited subscription"
+        );
+        assert!(
+            !rows.contains_key(&other_account_id),
+            "other-region account should NOT be processed by the inherited subscription"
+        );
+    }
+
+    // (4) An explicit .routing_key("other-region") on the SubscriptionBuilder still
+    // overrides the executor default. Use a separate subscription key to keep its
+    // cursor independent from the one above.
+    simple_explicit::subscription("simple_other")
+        .routing_key("other-region")
+        .unretry_execute(&evento)
+        .await?;
+
+    {
+        let rows = simple_explicit::ROWS.read().unwrap();
+        let other_row = rows.get(&other_account_id).expect(
+            "other-region account should be processed when subscription explicitly opts in",
+        );
+        assert_eq!(other_row.status, AccountStatus::Active);
+        assert!(
+            !rows.contains_key(&default_account_id),
+            "default-region account should NOT be processed by an explicit other-region subscription"
+        );
+    }
+
+    Ok(())
+}
+
 pub async fn subscribe_multiple_aggregator<E: Executor + Clone>(
     executor: &E,
 ) -> anyhow::Result<()> {
@@ -1445,6 +1534,46 @@ mod simple {
             event.aggregator_id.to_owned(),
             Row {
                 status: AccountStatus::Closed,
+            },
+        );
+
+        Ok(())
+    }
+}
+
+mod simple_explicit {
+    use std::{collections::HashMap, sync::RwLock};
+
+    use bank::aggregator::AccountOpened;
+    use bank::AccountStatus;
+    use evento::{
+        metadata::Event,
+        subscription::{Context, SubscriptionBuilder},
+        Executor,
+    };
+    use once_cell::sync::Lazy;
+
+    pub static ROWS: Lazy<RwLock<HashMap<String, Row>>> = Lazy::new(Default::default);
+
+    #[derive(Default)]
+    pub struct Row {
+        pub status: AccountStatus,
+    }
+
+    pub fn subscription<E: Executor>(key: impl Into<String>) -> SubscriptionBuilder<E> {
+        SubscriptionBuilder::new(key).handler(handle_account_opened())
+    }
+
+    #[evento::subscription]
+    async fn handle_account_opened<E: Executor>(
+        _context: &Context<'_, E>,
+        event: Event<AccountOpened>,
+    ) -> anyhow::Result<()> {
+        let mut rows = ROWS.write().unwrap();
+        rows.insert(
+            event.aggregator_id.to_owned(),
+            Row {
+                status: AccountStatus::Active,
             },
         );
 


### PR DESCRIPTION
## Summary
- `Executor::default_routing_key()` trait method (default `None`); `Evento` exposes a builder-style `.default_routing_key(key)` and overrides it. `EventoGroup`/`Rw` delegate to first/writer.
- `Evento::write` fills `event.routing_key` from the default when the event has none; explicit per-aggregator `.routing_key()` still wins.
- `SubscriptionBuilder` and `ProjectionSubscription` now store `Option<RoutingKey>`. When neither `.routing_key()` nor `.all()` is set, they inherit the executor's default at `start()` / `execute()` time.
- `SubscriptionBuilder::execute` takes `&mut self` (resolution writes back the resolved key).

## Test plan
- [x] `cargo check --workspace --all-features`
- [x] `cargo test --test sqlite --all-features` (31 passed, incl. new `sqlite_subscribe_default_routing_key`)
- [x] `cargo test --test fjall --all-features` (14 passed, incl. new `fjall_subscribe_default_routing_key`)
- [x] New `evento_test::subscribe_default_routing_key` covers: (1) default fills missing key on write, (2) explicit per-aggregator key wins, (3) subscription inherits default, (4) explicit `.routing_key()` on builder overrides default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)