### PR TITLE
fix(subscription): scope storage key by executor default routing key

### DIFF
--- a/evento-core/src/subscription.rs
+++ b/evento-core/src/subscription.rs
@@ -144,6 +144,7 @@ pub struct SubscriptionBuilder<E: Executor> {
     handlers: HashMap<String, Box<dyn Handler<E>>>,
     context: context::RwContext,
     routing_key: Option<RoutingKey>,
+    prefix_key: Option<String>,
     delay: Option<Duration>,
     chunk_size: u16,
     is_accept_failure: bool,
@@ -168,6 +169,7 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
             chunk_size: 300,
             is_accept_failure: false,
             routing_key: None,
+            prefix_key: None,
             aggregators: Default::default(),
             shutdown_rx: None,
         }
@@ -304,19 +306,32 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
     }
 
     fn key(&self) -> String {
-        if let Some(RoutingKey::Value(Some(ref key))) = self.routing_key {
-            return format!("{key}.{}", self.key);
+        let prefix = match &self.routing_key {
+            Some(RoutingKey::Value(Some(k))) => Some(k.as_str()),
+            Some(RoutingKey::All) => self.prefix_key.as_deref(),
+            _ => None,
+        };
+        match prefix {
+            Some(p) => format!("{p}.{}", self.key),
+            None => self.key.to_owned(),
         }
-
-        self.key.to_owned()
     }
 
-    /// Resolves an unset routing key from the executor's default.
+    /// Resolves an unset routing key from the executor's default and captures
+    /// the default as a storage-key prefix.
     ///
     /// Called once at the top of `start()` / `execute()` before any other
     /// method reads `self.routing_key`. After this, `routing_key` is always
     /// `Some(_)`.
+    ///
+    /// `prefix_key` is captured from `executor.default_routing_key()` even
+    /// when the user has already called `.all()`, so the storage key remains
+    /// scoped to the executor's tenant — otherwise two executors with
+    /// different defaults would share one row in the subscriber table.
     fn resolve_routing_key(&mut self, executor: &E) {
+        if self.prefix_key.is_none() {
+            self.prefix_key = executor.default_routing_key().map(|s| s.to_owned());
+        }
         if self.routing_key.is_some() {
             return;
         }

--- a/evento-fjall/tests/fjall.rs
+++ b/evento-fjall/tests/fjall.rs
@@ -90,6 +90,13 @@ async fn fjall_subscribe_default_routing_key() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn fjall_subscribe_default_routing_key_all_isolation() -> anyhow::Result<()> {
+    let (executor, _temp_dir) =
+        create_fjall_executor("subscribe_default_routing_key_all_isolation")?;
+    evento_test::subscribe_default_routing_key_all_isolation(&executor).await
+}
+
+#[tokio::test]
 async fn fjall_all_commands() -> anyhow::Result<()> {
     let (executor, _temp_dir) = create_fjall_executor("all_commands")?;
     evento_test::all_commands(&executor).await

--- a/evento-sql/tests/sqlite.rs
+++ b/evento-sql/tests/sqlite.rs
@@ -104,6 +104,14 @@ async fn sqlite_subscribe_default_routing_key() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn sqlite_subscribe_default_routing_key_all_isolation() -> anyhow::Result<()> {
+    let pool = create_sqlite_pool("subscribe_default_routing_key_all_isolation").await?;
+
+    evento_test::subscribe_default_routing_key_all_isolation::<Sql<sqlx::Sqlite>>(&pool.into())
+        .await
+}
+
+#[tokio::test]
 async fn sqlite_all_commands() -> anyhow::Result<()> {
     let pool = create_sqlite_pool("all_commands").await?;
 

--- a/evento-test/src/lib.rs
+++ b/evento-test/src/lib.rs
@@ -868,6 +868,87 @@ pub async fn subscribe_default_routing_key<E: Executor + Clone>(
     Ok(())
 }
 
+/// Regression test for the bug where two Evento wrappers with different
+/// `default_routing_key` values shared the same row in the subscriber table
+/// when subscriptions called `.all()`, so the second tenant inherited the
+/// first tenant's cursor and never replayed.
+///
+/// The storage key for `.all()` must include the executor's default routing
+/// key as a prefix; otherwise tenant-b reads from where tenant-a stopped.
+pub async fn subscribe_default_routing_key_all_isolation<E: Executor + Clone>(
+    executor: &E,
+) -> anyhow::Result<()> {
+    let evento_a = evento::Evento::new(executor.clone()).default_routing_key("tenant-a");
+    let evento_b = evento::Evento::new(executor.clone()).default_routing_key("tenant-b");
+    let cmd_a = bank::Command(evento_a.clone());
+    let cmd_b = bank::Command(evento_b.clone());
+
+    let acc_a = cmd_a
+        .open_account(OpenAccount {
+            owner_id: "owner_a".to_owned(),
+            owner_name: "A".to_owned(),
+            account_type: AccountType::Checking,
+            currency: "USD".to_owned(),
+            initial_balance: 100,
+        })
+        .await?;
+    let acc_b = cmd_b
+        .open_account(OpenAccount {
+            owner_id: "owner_b".to_owned(),
+            owner_name: "B".to_owned(),
+            account_type: AccountType::Checking,
+            currency: "USD".to_owned(),
+            initial_balance: 200,
+        })
+        .await?;
+
+    // Tenant-a runs .all() — should process both events (it reads all routing keys).
+    simple::subscription()
+        .all()
+        .unretry_execute(&evento_a)
+        .await?;
+    {
+        let rows = simple::ROWS.read().unwrap();
+        assert!(
+            rows.contains_key(&acc_a),
+            "tenant-a .all() should process acc_a"
+        );
+        assert!(
+            rows.contains_key(&acc_b),
+            "tenant-a .all() should process acc_b"
+        );
+    }
+
+    // Wipe the projection so we can observe whether tenant-b actually re-reads
+    // the events from its own cursor (which should start fresh).
+    {
+        let mut rows = simple::ROWS.write().unwrap();
+        rows.remove(&acc_a);
+        rows.remove(&acc_b);
+    }
+
+    // Tenant-b runs .all() — with the fix, it has its own cursor (storage key
+    // "tenant-b.simple" vs tenant-a's "tenant-a.simple") and replays both
+    // events from the beginning.
+    simple::subscription()
+        .all()
+        .unretry_execute(&evento_b)
+        .await?;
+    {
+        let rows = simple::ROWS.read().unwrap();
+        assert!(
+            rows.contains_key(&acc_a),
+            "tenant-b .all() must replay acc_a — without per-tenant cursor scoping it would inherit tenant-a's position"
+        );
+        assert!(
+            rows.contains_key(&acc_b),
+            "tenant-b .all() must replay acc_b"
+        );
+    }
+
+    Ok(())
+}
+
 pub async fn subscribe_multiple_aggregator<E: Executor + Clone>(
     executor: &E,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
## Summary
- Two Evento instances with different `default_routing_key` values (e.g. `tenant-a` and `tenant-b`) collided on the same row in the `subscriber` table when their subscriptions called `.all()`. The second tenant inherited the first tenant's cursor and never replayed.
- Cause: `SubscriptionBuilder::key()` only prefixed the storage key with `RoutingKey::Value(Some(_))` — `.all()` produced `RoutingKey::All`, which dropped the prefix and let both tenants share the row `subscriber.key = "my-sub"`.
- Fix: captured the executor's default into a new `prefix_key` field (populated in `resolve_routing_key`) used only inside `key()`. With a default set, `.all()` now stores under `"{default}.{key}"`. Filter inheritance on `routing_key` is untouched.

Resulting storage keys:
- `Evento(default="tenant-a")` + `.all()` → `tenant-a.my-sub`
- `Evento(default="tenant-b")` + `.all()` → `tenant-b.my-sub` (separate cursor — replays as expected)
- `Evento(default="tenant-a")` + `.routing_key("other")` → `other.my-sub` (unchanged)
- No default + `.all()` → `my-sub` (unchanged)

`ProjectionSubscription` needs no separate change — it delegates to `SubscriptionBuilder` (`projection.rs:671-676`).

## Test plan
- [x] Added regression test `subscribe_default_routing_key_all_isolation` (two Evento instances on the same store, different defaults, both `.all()` — asserts tenant-b replays after wiping the projection)
- [x] Wired into `evento-sql/tests/sqlite.rs` and `evento-fjall/tests/fjall.rs`
- [x] sqlite suite: 32/32 pass
- [x] fjall suite: 15/15 pass
- [ ] postgres + mysql suites (not wired — those test files don't include `subscribe_default_routing_key`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)