### PR TITLE
feat(fjall): upgrade to 3.1 and finish Executor implementation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,4 +15,4 @@ jobs:
     with:
       mysql: true
       postgres: true
-      tests: '["make test.core", "make test.sql"]'
+      tests: '["make test.core", "make test.sql", "make test.fjall"]'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bank-axum-fjall"
+version = "2.0.0-alpha.20"
+dependencies = [
+ "anyhow",
+ "askama",
+ "axum",
+ "bank",
+ "evento",
+ "serde",
+ "tempfile",
+ "tokio",
+ "ulid",
+]
+
+[[package]]
 name = "bank-axum-sqlite"
 version = "2.0.0-alpha.20"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,6 +341,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -348,9 +354,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "byteview"
-version = "0.6.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6236364b88b9b6d0bc181ba374cf1ab55ba3ef97a1cb6f8cddad48a273767fb5"
+checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
 name = "cc"
@@ -695,12 +701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "double-ended-peekable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d05e1c0dbad51b52c38bda7adceef61b9efc2baf04acfe8726a8c4630a6f57"
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +763,7 @@ name = "evento"
 version = "2.0.0-alpha.20"
 dependencies = [
  "evento-core",
+ "evento-fjall",
  "evento-sql",
  "evento-sql-migrator",
  "sqlx_migrator",
@@ -868,17 +869,17 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fjall"
-version = "2.11.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25ad44cd4360a0448a9b5a0a6f1c7a621101cca4578706d43c9a821418aebc"
+checksum = "b62b25b4d815ae178d7d9e4aa32ee59f072efd5431c736abede1e6ee13c8c453"
 dependencies = [
- "byteorder",
+ "byteorder-lite",
  "byteview",
  "dashmap",
+ "flume",
  "log",
  "lsm-tree",
- "path-absolutize",
- "std-semaphore",
+ "lz4_flex",
  "tempfile",
  "xxhash-rust",
 ]
@@ -1063,12 +1064,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "guardian"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "hashbrown"
@@ -1464,33 +1459,34 @@ checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
 
 [[package]]
 name = "lsm-tree"
-version = "2.10.4"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799399117a2bfb37660e08be33f470958babb98386b04185288d829df362ea15"
+checksum = "e447ac67ff6aef4ec07fc19e507b219336cbba90a697c0dbeb1bf51b91536b67"
 dependencies = [
- "byteorder",
+ "byteorder-lite",
+ "byteview",
  "crossbeam-skiplist",
- "double-ended-peekable",
  "enum_dispatch",
- "guardian",
  "interval-heap",
  "log",
  "lz4_flex",
- "path-absolutize",
  "quick_cache",
  "rustc-hash",
  "self_cell",
+ "sfa",
  "tempfile",
- "value-log",
  "varint-rs",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "matchit"
@@ -1579,24 +1575,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
-]
-
-[[package]]
-name = "path-absolutize"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
-dependencies = [
- "path-dedot",
-]
-
-[[package]]
-name = "path-dedot"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]
@@ -1946,6 +1924,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sfa"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1296838937cab56cd6c4eeeb8718ec777383700c33f060e2869867bd01d1175"
+dependencies = [
+ "byteorder-lite",
+ "log",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,12 +2248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
-name = "std-semaphore"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ae9eec00137a8eed469fb4148acd9fc6ac8c3f9b110f52cd34698c8b5bfa0e"
-
-[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,6 +2450,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2545,23 +2534,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "value-log"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fc7c4ce161f049607ecea654dca3f2d727da5371ae85e2e4f14ce2b98ed67c"
-dependencies = [
- "byteorder",
- "byteview",
- "interval-heap",
- "log",
- "path-absolutize",
- "rustc-hash",
- "tempfile",
- "varint-rs",
- "xxhash-rust",
-]
 
 [[package]]
 name = "varint-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ sqlx = { version = "0.9" }
 sqlx_migrator = "0.19"
 sea-query = { version = "1.0.1", default-features = false, features = ["derive", "audit"] }
 sea-query-sqlx = { version = "0.9.1", features = ["runtime-tokio"] }
-fjall = "2.11"
+fjall = "3.1"
 
 # Proc macro
 quote = "1.0"

--- a/evento-fjall/Cargo.toml
+++ b/evento-fjall/Cargo.toml
@@ -4,6 +4,7 @@ version = "2.0.0-alpha.20"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+publish = true
 description = "Fjall embedded key-value store implementation for evento event sourcing library"
 documentation = "https://docs.rs/evento-fjall"
 readme = "README.md"
@@ -20,3 +21,7 @@ fjall.workspace = true
 [dev-dependencies]
 tempfile = "3.27"
 evento-test = { path = "../evento-test" }
+
+[features]
+default = ["rw"]
+rw = ["evento-core/rw"]

--- a/evento-fjall/src/lib.rs
+++ b/evento-fjall/src/lib.rs
@@ -49,15 +49,16 @@
 //! - `routing_index` - Routing key index: `{routing_key}\0{ULID}` -> `()`
 //! - `type_index` - Event type index: `{type}\0{name}\0{ULID}` -> `()`
 //! - `subscribers` - Subscription state: `{key}` -> `SubscriberState`
+//! - `snapshots` - Aggregate snapshots: `{type}\0{id}` -> `StoredSnapshot`
 
 use std::path::Path;
 
 use evento_core::{
-    cursor::{Args, Cursor, ReadResult, Value},
+    cursor::{Args, ReadResult, Value},
     metadata::Metadata,
     Event, Executor, ReadAggregator, RoutingKey, WriteError,
 };
-use fjall::{Config, Keyspace, Partition, PartitionCreateOptions, PersistMode};
+use fjall::{Database, Keyspace, KeyspaceCreateOptions, PersistMode};
 use ulid::Ulid;
 
 /// Subscriber state stored in the database.
@@ -66,6 +67,14 @@ struct SubscriberState {
     worker_id: String,
     cursor: Option<String>,
     lag: u64,
+}
+
+/// Snapshot record stored in the database.
+#[derive(Debug, Clone, bitcode::Encode, bitcode::Decode)]
+struct StoredSnapshot {
+    revision: String,
+    data: Vec<u8>,
+    cursor: String,
 }
 
 /// Stored event in fjall format.
@@ -134,29 +143,30 @@ impl TryFrom<StoredEvent> for Event {
 /// let executor = Fjall::open("./events.db")?;
 ///
 /// // Or with custom configuration
-/// let keyspace = fjall::Config::new("./events.db")
-///     .max_write_buffer_size(64 * 1024 * 1024)
+/// let db = fjall::Database::builder("./events.db")
 ///     .open()?;
-/// let executor = Fjall::from_keyspace(keyspace)?;
+/// let executor = Fjall::from_database(db)?;
 /// ```
 pub struct Fjall {
-    keyspace: Keyspace,
-    events: Partition,
-    agg_index: Partition,
-    routing_index: Partition,
-    type_index: Partition,
-    subscribers: Partition,
+    db: Database,
+    events: Keyspace,
+    agg_index: Keyspace,
+    routing_index: Keyspace,
+    type_index: Keyspace,
+    subscribers: Keyspace,
+    snapshots: Keyspace,
 }
 
 impl Clone for Fjall {
     fn clone(&self) -> Self {
         Self {
-            keyspace: self.keyspace.clone(),
+            db: self.db.clone(),
             events: self.events.clone(),
             agg_index: self.agg_index.clone(),
             routing_index: self.routing_index.clone(),
             type_index: self.type_index.clone(),
             subscribers: self.subscribers.clone(),
+            snapshots: self.snapshots.clone(),
         }
     }
 }
@@ -168,41 +178,39 @@ impl Fjall {
     ///
     /// # Errors
     ///
-    /// Returns an error if the database cannot be opened or partitions
+    /// Returns an error if the database cannot be opened or keyspaces
     /// cannot be created.
     pub fn open(path: impl AsRef<Path>) -> anyhow::Result<Self> {
-        let keyspace = Config::new(path).open()?;
-        Self::from_keyspace(keyspace)
+        let db = Database::builder(path).open()?;
+        Self::from_database(db)
     }
 
-    /// Creates an executor from an existing keyspace.
+    /// Creates an executor from an existing database.
     ///
-    /// Use this when you need custom keyspace configuration.
+    /// Use this when you need custom database configuration.
     ///
     /// # Example
     ///
     /// ```rust,ignore
-    /// let keyspace = fjall::Config::new("./events.db")
-    ///     .max_write_buffer_size(128 * 1024 * 1024)
+    /// let db = fjall::Database::builder("./events.db")
     ///     .open()?;
-    /// let executor = Fjall::from_keyspace(keyspace)?;
+    /// let executor = Fjall::from_database(db)?;
     /// ```
-    pub fn from_keyspace(keyspace: Keyspace) -> anyhow::Result<Self> {
-        let opts = PartitionCreateOptions::default();
-
+    pub fn from_database(db: Database) -> anyhow::Result<Self> {
         Ok(Self {
-            events: keyspace.open_partition("events", opts.clone())?,
-            agg_index: keyspace.open_partition("agg_index", opts.clone())?,
-            routing_index: keyspace.open_partition("routing_index", opts.clone())?,
-            type_index: keyspace.open_partition("type_index", opts.clone())?,
-            subscribers: keyspace.open_partition("subscribers", opts)?,
-            keyspace,
+            events: db.keyspace("events", KeyspaceCreateOptions::default)?,
+            agg_index: db.keyspace("agg_index", KeyspaceCreateOptions::default)?,
+            routing_index: db.keyspace("routing_index", KeyspaceCreateOptions::default)?,
+            type_index: db.keyspace("type_index", KeyspaceCreateOptions::default)?,
+            subscribers: db.keyspace("subscribers", KeyspaceCreateOptions::default)?,
+            snapshots: db.keyspace("snapshots", KeyspaceCreateOptions::default)?,
+            db,
         })
     }
 
-    /// Returns a reference to the underlying keyspace.
-    pub fn keyspace(&self) -> &Keyspace {
-        &self.keyspace
+    /// Returns a reference to the underlying database.
+    pub fn database(&self) -> &Database {
+        &self.db
     }
 
     /// Persists all pending writes to disk.
@@ -210,7 +218,7 @@ impl Fjall {
     /// By default, writes are persisted after each batch. Call this
     /// if you need to ensure durability at a specific point.
     pub fn persist(&self) -> anyhow::Result<()> {
-        self.keyspace.persist(PersistMode::SyncAll)?;
+        self.db.persist(PersistMode::SyncAll)?;
         Ok(())
     }
 
@@ -250,6 +258,11 @@ impl Fjall {
         format!("{}\x00", routing_key)
     }
 
+    /// Builds the snapshot key.
+    fn snapshot_key(aggregator_type: &str, id: &str) -> Vec<u8> {
+        format!("{}\x00{}", aggregator_type, id).into_bytes()
+    }
+
     /// Gets the last version for an aggregate.
     fn get_last_version(
         &self,
@@ -258,10 +271,10 @@ impl Fjall {
     ) -> anyhow::Result<Option<u16>> {
         let prefix = Self::agg_prefix(aggregator_type, aggregator_id);
 
-        if let Some(result) = self.agg_index.prefix(&prefix).next_back() {
-            let kv = result?;
+        if let Some(guard) = self.agg_index.prefix(&prefix).next_back() {
+            let (key, _) = guard.into_inner()?;
             // Version is the last 2 bytes of the key
-            let key_bytes = kv.0.as_ref();
+            let key_bytes = key.as_ref();
             if key_bytes.len() >= 2 {
                 let version_bytes: [u8; 2] = key_bytes[key_bytes.len() - 2..].try_into().unwrap();
                 return Ok(Some(u16::from_be_bytes(version_bytes)));
@@ -275,7 +288,7 @@ impl Fjall {
     fn load_event(&self, id: &Ulid) -> anyhow::Result<Option<Event>> {
         match self.events.get(id.to_bytes())? {
             Some(bytes) => {
-                let stored: StoredEvent = bitcode::decode(&bytes)
+                let stored: StoredEvent = bitcode::decode(bytes.as_ref())
                     .map_err(|e| anyhow::anyhow!("Failed to deserialize event: {}", e))?;
                 Ok(Some(stored.try_into()?))
             }
@@ -310,9 +323,9 @@ impl Fjall {
                         // Specific aggregate ID with event name filter
                         (Some(id), Some(name)) => {
                             let prefix = Self::agg_prefix(&agg.aggregator_type, id);
-                            for kv in self.agg_index.prefix(&prefix) {
-                                let kv = kv?;
-                                let ulid_bytes: [u8; 16] = kv.1.as_ref().try_into()?;
+                            for guard in self.agg_index.prefix(&prefix) {
+                                let (_, value) = guard.into_inner()?;
+                                let ulid_bytes: [u8; 16] = value.as_ref().try_into()?;
                                 let ulid = Ulid::from_bytes(ulid_bytes);
 
                                 // Check if event matches name filter
@@ -326,18 +339,18 @@ impl Fjall {
                         // Specific aggregate ID, all events
                         (Some(id), None) => {
                             let prefix = Self::agg_prefix(&agg.aggregator_type, id);
-                            for kv in self.agg_index.prefix(&prefix) {
-                                let kv = kv?;
-                                let ulid_bytes: [u8; 16] = kv.1.as_ref().try_into()?;
+                            for guard in self.agg_index.prefix(&prefix) {
+                                let (_, value) = guard.into_inner()?;
+                                let ulid_bytes: [u8; 16] = value.as_ref().try_into()?;
                                 add_unique!(Ulid::from_bytes(ulid_bytes));
                             }
                         }
                         // All aggregates of type, specific event name
                         (None, Some(name)) => {
                             let prefix = Self::type_prefix(&agg.aggregator_type, name);
-                            for kv in self.type_index.prefix(&prefix) {
-                                let kv = kv?;
-                                let key_bytes = kv.0.as_ref();
+                            for guard in self.type_index.prefix(&prefix) {
+                                let (key, _) = guard.into_inner()?;
+                                let key_bytes = key.as_ref();
                                 if key_bytes.len() >= 16 {
                                     let ulid_bytes: [u8; 16] =
                                         key_bytes[key_bytes.len() - 16..].try_into()?;
@@ -348,9 +361,9 @@ impl Fjall {
                         // All events of aggregator type - scan all
                         (None, None) => {
                             let prefix = format!("{}\x00", agg.aggregator_type);
-                            for kv in self.agg_index.prefix(&prefix) {
-                                let kv = kv?;
-                                let ulid_bytes: [u8; 16] = kv.1.as_ref().try_into()?;
+                            for guard in self.agg_index.prefix(&prefix) {
+                                let (_, value) = guard.into_inner()?;
+                                let ulid_bytes: [u8; 16] = value.as_ref().try_into()?;
                                 add_unique!(Ulid::from_bytes(ulid_bytes));
                             }
                         }
@@ -360,9 +373,9 @@ impl Fjall {
             // Query by routing key only
             (None, Some(RoutingKey::Value(Some(ref key)))) => {
                 let prefix = Self::routing_prefix(key);
-                for kv in self.routing_index.prefix(&prefix) {
-                    let kv = kv?;
-                    let key_bytes = kv.0.as_ref();
+                for guard in self.routing_index.prefix(&prefix) {
+                    let (key, _) = guard.into_inner()?;
+                    let key_bytes = key.as_ref();
                     if key_bytes.len() >= 16 {
                         let ulid_bytes: [u8; 16] = key_bytes[key_bytes.len() - 16..].try_into()?;
                         add_unique!(Ulid::from_bytes(ulid_bytes));
@@ -371,9 +384,9 @@ impl Fjall {
             }
             // Query all events
             _ => {
-                for kv in self.events.iter() {
-                    let kv = kv?;
-                    let ulid_bytes: [u8; 16] = kv.0.as_ref().try_into()?;
+                for guard in self.events.iter() {
+                    let (key, _) = guard.into_inner()?;
+                    let ulid_bytes: [u8; 16] = key.as_ref().try_into()?;
                     add_unique!(Ulid::from_bytes(ulid_bytes));
                 }
             }
@@ -407,7 +420,7 @@ impl Executor for Fjall {
             }
 
             // Write atomically using batch
-            let mut batch = executor.keyspace.batch();
+            let mut batch = executor.db.batch();
 
             for event in &events {
                 let id_bytes = event.id.to_bytes();
@@ -415,7 +428,7 @@ impl Executor for Fjall {
                 let event_bytes = bitcode::encode(&stored);
 
                 // Primary: ULID -> Event
-                batch.insert(&executor.events, id_bytes, event_bytes.as_slice());
+                batch.insert(&executor.events, id_bytes, event_bytes);
 
                 // Aggregate index: {type}\0{id}\0{version} -> ULID
                 let agg_key =
@@ -435,7 +448,7 @@ impl Executor for Fjall {
 
             batch.commit().map_err(|e| WriteError::Unknown(e.into()))?;
             executor
-                .keyspace
+                .db
                 .persist(PersistMode::SyncAll)
                 .map_err(|e| WriteError::Unknown(e.into()))?;
 
@@ -454,43 +467,17 @@ impl Executor for Fjall {
         let executor = self.clone();
 
         tokio::task::spawn_blocking(move || {
-            let is_backward = args.is_backward();
-            let (limit, cursor) = args.get_info();
+            // Collect matching event IDs (deduplicated across the aggregator filters).
+            let event_ids = executor.collect_event_ids(&aggregators, &routing_key)?;
 
-            // Collect matching event IDs
-            let mut event_ids = executor.collect_event_ids(&aggregators, &routing_key)?;
-
-            // Sort by ULID (time-ordered)
-            event_ids.sort();
-            if is_backward {
-                event_ids.reverse();
-            }
-
-            // Apply cursor filter
-            if let Some(ref cursor_value) = cursor {
-                let cursor_data = Event::deserialize_cursor(cursor_value)?;
-                let cursor_ulid = Ulid::from_string(&cursor_data.i)?;
-
-                event_ids.retain(|id| {
-                    if is_backward {
-                        *id < cursor_ulid
-                    } else {
-                        *id > cursor_ulid
-                    }
-                });
-            }
-
-            // Load events, filtering by routing key, until we have enough
-            let target_count = (limit + 1) as usize;
-            let mut events = Vec::new();
-
+            // Load every matching event and apply the routing-key filter. The cursor
+            // is intentionally NOT pre-filtered here: `Event`'s cursor uses
+            // (timestamp, subsec, version, id), which can disagree with raw ULID
+            // ordering when events land in the same millisecond. `Reader::execute`
+            // applies the canonical sort, cursor predicate, and limit.
+            let mut events = Vec::with_capacity(event_ids.len());
             for id in event_ids {
-                if events.len() >= target_count {
-                    break;
-                }
-
                 if let Some(event) = executor.load_event(&id)? {
-                    // Apply routing key filter if specified
                     let matches = match &routing_key {
                         Some(RoutingKey::Value(Some(ref key))) => {
                             event.routing_key.as_ref() == Some(key)
@@ -505,7 +492,6 @@ impl Executor for Fjall {
                 }
             }
 
-            // Build paginated result
             evento_core::cursor::Reader::new(events)
                 .args(args)
                 .execute()
@@ -530,7 +516,7 @@ impl Executor for Fjall {
 
         tokio::task::spawn_blocking(move || match executor.subscribers.get(&key)? {
             Some(bytes) => {
-                let state: SubscriberState = bitcode::decode(&bytes)
+                let state: SubscriberState = bitcode::decode(bytes.as_ref())
                     .map_err(|e| anyhow::anyhow!("Failed to deserialize subscriber: {}", e))?;
                 Ok(state.cursor.map(Value))
             }
@@ -544,7 +530,7 @@ impl Executor for Fjall {
 
         tokio::task::spawn_blocking(move || match executor.subscribers.get(&key)? {
             Some(bytes) => {
-                let state: SubscriberState = bitcode::decode(&bytes)
+                let state: SubscriberState = bitcode::decode(bytes.as_ref())
                     .map_err(|e| anyhow::anyhow!("Failed to deserialize subscriber: {}", e))?;
                 Ok(state.worker_id == worker_id.to_string())
             }
@@ -560,7 +546,7 @@ impl Executor for Fjall {
             // Try to preserve existing cursor if subscriber exists
             let cursor = match executor.subscribers.get(&key)? {
                 Some(bytes) => {
-                    let state: SubscriberState = bitcode::decode(&bytes)
+                    let state: SubscriberState = bitcode::decode(bytes.as_ref())
                         .map_err(|e| anyhow::anyhow!("Failed to deserialize subscriber: {}", e))?;
                     state.cursor
                 }
@@ -573,7 +559,9 @@ impl Executor for Fjall {
                 lag: 0,
             };
 
-            executor.subscribers.insert(&key, bitcode::encode(&state))?;
+            executor
+                .subscribers
+                .insert(key.as_bytes(), bitcode::encode(&state))?;
             Ok(())
         })
         .await?
@@ -585,7 +573,7 @@ impl Executor for Fjall {
         tokio::task::spawn_blocking(move || {
             let state = match executor.subscribers.get(&key)? {
                 Some(bytes) => {
-                    let mut state: SubscriberState = bitcode::decode(&bytes)
+                    let mut state: SubscriberState = bitcode::decode(bytes.as_ref())
                         .map_err(|e| anyhow::anyhow!("Failed to deserialize subscriber: {}", e))?;
                     state.cursor = Some(cursor.0);
                     state.lag = lag;
@@ -594,7 +582,9 @@ impl Executor for Fjall {
                 None => anyhow::bail!("Subscriber not found: {}", key),
             };
 
-            executor.subscribers.insert(&key, bitcode::encode(&state))?;
+            executor
+                .subscribers
+                .insert(key.as_bytes(), bitcode::encode(&state))?;
             Ok(())
         })
         .await?
@@ -602,34 +592,80 @@ impl Executor for Fjall {
 
     async fn get_snapshot(
         &self,
-        _aggregator_type: String,
-        _aggregator_revision: String,
-        _id: String,
+        aggregator_type: String,
+        aggregator_revision: String,
+        id: String,
     ) -> anyhow::Result<Option<(Vec<u8>, Value)>> {
-        todo!()
+        let executor = self.clone();
+
+        tokio::task::spawn_blocking(move || {
+            let key = Fjall::snapshot_key(&aggregator_type, &id);
+            match executor.snapshots.get(&key)? {
+                Some(bytes) => {
+                    let stored: StoredSnapshot = bitcode::decode(bytes.as_ref())
+                        .map_err(|e| anyhow::anyhow!("Failed to deserialize snapshot: {}", e))?;
+
+                    // Revision mismatch invalidates the snapshot (forces a rebuild).
+                    if stored.revision != aggregator_revision {
+                        return Ok(None);
+                    }
+
+                    Ok(Some((stored.data, Value(stored.cursor))))
+                }
+                None => Ok(None),
+            }
+        })
+        .await?
     }
 
     async fn save_snapshot(
         &self,
-        _aggregator_type: String,
-        _aggregator_revision: String,
-        _id: String,
-        _data: Vec<u8>,
-        _cursor: Value,
+        aggregator_type: String,
+        aggregator_revision: String,
+        id: String,
+        data: Vec<u8>,
+        cursor: Value,
     ) -> anyhow::Result<()> {
-        todo!()
+        let executor = self.clone();
+
+        tokio::task::spawn_blocking(move || {
+            let key = Fjall::snapshot_key(&aggregator_type, &id);
+            let stored = StoredSnapshot {
+                revision: aggregator_revision,
+                data,
+                cursor: cursor.0,
+            };
+
+            executor.snapshots.insert(key, bitcode::encode(&stored))?;
+            Ok(())
+        })
+        .await?
     }
 
-    async fn delete_snapshot(&self, _aggregator_type: String, _id: String) -> anyhow::Result<()> {
-        todo!()
+    async fn delete_snapshot(&self, aggregator_type: String, id: String) -> anyhow::Result<()> {
+        let executor = self.clone();
+
+        tokio::task::spawn_blocking(move || {
+            let key = Fjall::snapshot_key(&aggregator_type, &id);
+            executor.snapshots.remove(key)?;
+            Ok(())
+        })
+        .await?
     }
 }
 
-impl From<Keyspace> for Fjall {
-    fn from(keyspace: Keyspace) -> Self {
-        Self::from_keyspace(keyspace).expect("Failed to create Fjall from keyspace")
+impl From<Database> for Fjall {
+    fn from(db: Database) -> Self {
+        Self::from_database(db).expect("Failed to create Fjall from database")
     }
 }
+
+/// Read-write executor pair for Fjall.
+///
+/// Used in CQRS patterns where reads and writes are routed to the same
+/// embedded store; both halves share a single Fjall handle.
+#[cfg(feature = "rw")]
+pub type RwFjall = evento_core::Rw<Fjall, Fjall>;
 
 #[cfg(test)]
 mod tests {
@@ -730,5 +766,92 @@ mod tests {
         // Check cursor is updated
         let cursor = executor.get_subscriber_cursor(key).await.unwrap();
         assert_eq!(cursor.unwrap().0, "test-cursor");
+    }
+
+    #[tokio::test]
+    async fn test_snapshot_lifecycle() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let executor = Fjall::open(temp_dir.path()).unwrap();
+
+        let aggregator_type = "test/Account".to_string();
+        let revision = "1".to_string();
+        let id = "agg-1".to_string();
+        let data = vec![10, 20, 30];
+        let cursor = Value("cursor-1".to_string());
+
+        // Initially: no snapshot
+        let result = executor
+            .get_snapshot(aggregator_type.clone(), revision.clone(), id.clone())
+            .await
+            .unwrap();
+        assert!(result.is_none());
+
+        // Save snapshot
+        executor
+            .save_snapshot(
+                aggregator_type.clone(),
+                revision.clone(),
+                id.clone(),
+                data.clone(),
+                cursor.clone(),
+            )
+            .await
+            .unwrap();
+
+        // Get matching revision returns the snapshot
+        let (got_data, got_cursor) = executor
+            .get_snapshot(aggregator_type.clone(), revision.clone(), id.clone())
+            .await
+            .unwrap()
+            .expect("snapshot should exist");
+        assert_eq!(got_data, data);
+        assert_eq!(got_cursor.0, cursor.0);
+
+        // Get with different revision returns None (revision invalidation)
+        let result = executor
+            .get_snapshot(aggregator_type.clone(), "2".to_string(), id.clone())
+            .await
+            .unwrap();
+        assert!(result.is_none());
+
+        // Overwriting with a new revision works
+        let new_data = vec![40, 50];
+        let new_cursor = Value("cursor-2".to_string());
+        executor
+            .save_snapshot(
+                aggregator_type.clone(),
+                "2".to_string(),
+                id.clone(),
+                new_data.clone(),
+                new_cursor.clone(),
+            )
+            .await
+            .unwrap();
+
+        let (got_data, got_cursor) = executor
+            .get_snapshot(aggregator_type.clone(), "2".to_string(), id.clone())
+            .await
+            .unwrap()
+            .expect("snapshot should exist");
+        assert_eq!(got_data, new_data);
+        assert_eq!(got_cursor.0, new_cursor.0);
+
+        // Delete snapshot
+        executor
+            .delete_snapshot(aggregator_type.clone(), id.clone())
+            .await
+            .unwrap();
+
+        let result = executor
+            .get_snapshot(aggregator_type, "2".to_string(), id.clone())
+            .await
+            .unwrap();
+        assert!(result.is_none());
+
+        // Delete is idempotent
+        executor
+            .delete_snapshot("test/Account".to_string(), id)
+            .await
+            .unwrap();
     }
 }

--- a/evento/Cargo.toml
+++ b/evento/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 evento-core = { path = "../evento-core", version = "2.0.0-alpha.20" }
 evento-sql = { path = "../evento-sql", optional = true, version = "2.0.0-alpha.20" }
 evento-sql-migrator = { path = "../evento-sql-migrator", optional = true, version = "2.0.0-alpha.20" }
+evento-fjall = { path = "../evento-fjall", optional = true, version = "2.0.0-alpha.20" }
 sqlx_migrator = { workspace = true, optional = true }
 
 [features]
@@ -24,3 +25,4 @@ sql = ["sqlite", "mysql", "postgres"]
 sqlite = ["evento-sql/sqlite", "evento-sql-migrator/sqlite", "sqlx_migrator/sqlite"]
 mysql = ["evento-sql/mysql", "evento-sql-migrator/mysql", "sqlx_migrator/mysql"]
 postgres = ["evento-sql/postgres", "evento-sql-migrator/postgres", "sqlx_migrator/postgres"]
+fjall = ["evento-fjall", "evento-fjall/rw", "rw"]

--- a/evento/src/lib.rs
+++ b/evento/src/lib.rs
@@ -221,3 +221,11 @@ pub use evento_sql::Postgres;
 /// SQLite executor type alias.
 #[cfg(feature = "sqlite")]
 pub use evento_sql::Sqlite;
+
+/// Fjall executor and types (requires `fjall` feature).
+#[cfg(feature = "fjall")]
+pub use evento_fjall as fjall;
+
+/// Fjall executor type alias.
+#[cfg(feature = "fjall")]
+pub use evento_fjall::Fjall;

--- a/examples/bank-axum-fjall/Cargo.toml
+++ b/examples/bank-axum-fjall/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bank-axum-fjall"
+version = "2.0.0-alpha.20"
+edition = "2021"
+
+[dependencies]
+bank.workspace = true
+evento = { workspace = true, features = ["fjall"] }
+axum.workspace = true
+askama.workspace = true
+tokio.workspace = true
+serde.workspace = true
+ulid.workspace = true
+anyhow.workspace = true
+tempfile = "3.27"

--- a/examples/bank-axum-fjall/src/main.rs
+++ b/examples/bank-axum-fjall/src/main.rs
@@ -1,0 +1,269 @@
+use std::sync::Arc;
+
+use askama::Template;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{Html, IntoResponse, Redirect, Response},
+    routing::{get, post},
+    Form, Router,
+};
+use bank::{
+    account_details, AccountType, Command, DepositMoney, OpenAccount, ReceiveMoney, TransferMoney,
+    WithdrawMoney, ACCOUNT_DETAILS_ROWS,
+};
+use evento::Fjall;
+use serde::Deserialize;
+use ulid::Ulid;
+
+type Executor = Fjall;
+
+#[derive(Clone)]
+struct AppState {
+    executor: Arc<Executor>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Open a Fjall-backed event store. A temp directory keeps each run
+    // self-contained; swap for a persistent path to keep data across runs.
+    let dir = tempfile::Builder::new()
+        .prefix("bank-axum-fjall-")
+        .tempdir()?;
+    println!("Fjall store: {}", dir.path().display());
+
+    let executor: Executor = Fjall::open(dir.path())?;
+
+    let state = AppState {
+        executor: Arc::new(executor),
+    };
+
+    let app = Router::new()
+        .route("/", get(index))
+        .route("/accounts", get(list_accounts))
+        .route("/accounts/new", get(new_account_form).post(create_account))
+        .route("/accounts/{id}", get(view_account))
+        .route("/accounts/{id}/deposit", post(deposit))
+        .route("/accounts/{id}/withdraw", post(withdraw))
+        .route("/accounts/{id}/transfer", post(transfer))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
+    println!("Listening on http://127.0.0.1:3000");
+    axum::serve(listener, app).await?;
+
+    // Keep the temp directory alive until the server shuts down.
+    drop(dir);
+
+    Ok(())
+}
+
+// Templates
+
+#[derive(Template)]
+#[template(path = "index.html")]
+struct IndexTemplate;
+
+#[derive(Template)]
+#[template(path = "accounts/list.html")]
+struct AccountsListTemplate {
+    accounts: Vec<AccountView>,
+}
+
+#[derive(Template)]
+#[template(path = "accounts/new.html")]
+struct NewAccountTemplate;
+
+#[derive(Template)]
+#[template(path = "accounts/view.html")]
+struct ViewAccountTemplate {
+    account: AccountView,
+    accounts: Vec<AccountView>,
+}
+
+struct AccountView {
+    id: String,
+    balance: i64,
+    currency: String,
+    status: String,
+}
+
+fn render<T: Template>(template: T) -> Response {
+    match template.render() {
+        Ok(html) => Html(html).into_response(),
+        Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response(),
+    }
+}
+
+// Handlers
+
+async fn index() -> Response {
+    render(IndexTemplate)
+}
+
+async fn list_accounts() -> Response {
+    let accounts = get_all_accounts();
+    render(AccountsListTemplate { accounts })
+}
+
+async fn new_account_form() -> Response {
+    render(NewAccountTemplate)
+}
+
+#[derive(Deserialize)]
+struct CreateAccountForm {
+    owner_name: String,
+    initial_balance: i64,
+    currency: String,
+}
+
+async fn create_account(
+    State(state): State<AppState>,
+    Form(form): Form<CreateAccountForm>,
+) -> impl IntoResponse {
+    let cmd = Command(state.executor.as_ref().clone());
+    let owner_id = Ulid::new().to_string();
+
+    let id = cmd
+        .open_account(OpenAccount {
+            owner_id,
+            owner_name: form.owner_name,
+            account_type: AccountType::Checking,
+            currency: form.currency,
+            initial_balance: form.initial_balance,
+        })
+        .await
+        .unwrap();
+
+    Redirect::to(&format!("/accounts/{id}"))
+}
+
+async fn view_account(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> Response {
+    let row = account_details::load(state.executor.as_ref(), &id, "")
+        .await
+        .unwrap();
+    let accounts = get_all_accounts();
+
+    match row {
+        Some(view) => {
+            let account = AccountView {
+                id: id.to_owned(),
+                balance: view.balance,
+                currency: view.currency.to_owned(),
+                status: format!("{:?}", view.status),
+            };
+            render(ViewAccountTemplate { account, accounts })
+        }
+        None => Html("<h1>Account not found</h1>".to_owned()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+struct DepositForm {
+    amount: i64,
+}
+
+async fn deposit(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+    Form(form): Form<DepositForm>,
+) -> impl IntoResponse {
+    let cmd = Command(state.executor.as_ref().clone());
+    let _ = cmd
+        .deposit_money(
+            &id,
+            DepositMoney {
+                amount: form.amount,
+                transaction_id: Ulid::new().to_string(),
+                description: "Web deposit".to_string(),
+            },
+        )
+        .await;
+
+    Redirect::to(&format!("/accounts/{}", id))
+}
+
+#[derive(Deserialize)]
+struct WithdrawForm {
+    amount: i64,
+}
+
+async fn withdraw(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+    Form(form): Form<WithdrawForm>,
+) -> impl IntoResponse {
+    let cmd = Command(state.executor.as_ref().clone());
+    let _ = cmd
+        .withdraw_money(
+            &id,
+            WithdrawMoney {
+                amount: form.amount,
+                transaction_id: Ulid::new().to_string(),
+                description: "Web withdrawal".to_string(),
+            },
+        )
+        .await;
+
+    Redirect::to(&format!("/accounts/{}", id))
+}
+
+#[derive(Deserialize)]
+struct TransferForm {
+    to_account_id: String,
+    amount: i64,
+}
+
+async fn transfer(
+    State(state): State<AppState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+    Form(form): Form<TransferForm>,
+) -> impl IntoResponse {
+    let cmd = Command(state.executor.as_ref().clone());
+    let transfer_tx = Ulid::new().to_string();
+
+    let _ = cmd
+        .transfer_money(
+            &id,
+            TransferMoney {
+                amount: form.amount,
+                to_account_id: form.to_account_id.clone(),
+                transaction_id: transfer_tx.clone(),
+                description: "Web transfer".to_string(),
+            },
+        )
+        .await;
+
+    // Mirror the sender's transfer with a matching receive on the destination,
+    // so the recipient's balance projection updates immediately.
+    let _ = cmd
+        .receive_money(
+            &form.to_account_id,
+            ReceiveMoney {
+                amount: form.amount,
+                from_account_id: id.clone(),
+                transaction_id: transfer_tx,
+                description: "Web transfer".to_string(),
+            },
+        )
+        .await;
+
+    Redirect::to(&format!("/accounts/{}", id))
+}
+
+// Helper functions
+
+fn get_all_accounts() -> Vec<AccountView> {
+    let rows = ACCOUNT_DETAILS_ROWS.read().unwrap();
+    rows.iter()
+        .map(|(id, view)| AccountView {
+            id: id.to_owned(),
+            balance: view.balance,
+            currency: view.currency.to_owned(),
+            status: format!("{:?}", view.status),
+        })
+        .collect()
+}

--- a/examples/bank-axum-fjall/templates/accounts/list.html
+++ b/examples/bank-axum-fjall/templates/accounts/list.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+
+{% block title %}Accounts - Evento Bank{% endblock %}
+
+{% block content %}
+<div class="card">
+    <h2>Accounts</h2>
+    {% if accounts.is_empty() %}
+    <p>No accounts yet. <a href="/accounts/new">Create one</a>.</p>
+    {% else %}
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Balance</th>
+                <th>Status</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for account in accounts %}
+            <tr>
+                <td><code>{{ account.id[..8] }}...</code></td>
+                <td>{{ account.balance }} {{ account.currency }}</td>
+                <td>{{ account.status }}</td>
+                <td><a href="/accounts/{{ account.id }}" class="btn">View</a></td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+</div>
+
+<p style="margin-top: 1rem;">
+    <a href="/accounts/new" class="btn btn-success">+ New Account</a>
+</p>
+{% endblock %}

--- a/examples/bank-axum-fjall/templates/accounts/new.html
+++ b/examples/bank-axum-fjall/templates/accounts/new.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}New Account - Evento Bank{% endblock %}
+
+{% block content %}
+<div class="card">
+    <h2>Create New Account</h2>
+    <form method="post" action="/accounts/new">
+        <div class="form-group">
+            <label for="owner_name">Owner Name</label>
+            <input type="text" id="owner_name" name="owner_name" required placeholder="John Doe">
+        </div>
+        <div class="form-group">
+            <label for="initial_balance">Initial Balance</label>
+            <input type="number" id="initial_balance" name="initial_balance" value="1000" min="0" required>
+        </div>
+        <div class="form-group">
+            <label for="currency">Currency</label>
+            <select id="currency" name="currency">
+                <option value="USD">USD</option>
+                <option value="EUR">EUR</option>
+                <option value="GBP">GBP</option>
+            </select>
+        </div>
+        <button type="submit" class="btn btn-success">Create Account</button>
+        <a href="/accounts" class="btn" style="background: #6b7280;">Cancel</a>
+    </form>
+</div>
+{% endblock %}

--- a/examples/bank-axum-fjall/templates/accounts/view.html
+++ b/examples/bank-axum-fjall/templates/accounts/view.html
@@ -1,0 +1,62 @@
+{% extends "base.html" %}
+
+{% block title %}Account {{ account.id[..8] }}... - Evento Bank{% endblock %}
+
+{% block content %}
+<div class="card">
+    <h2>Account Details</h2>
+    <p><strong>ID:</strong> <code>{{ account.id }}</code></p>
+    <p><strong>Status:</strong> {{ account.status }}</p>
+    <p class="balance {% if account.balance < 0 %}negative{% endif %}" style="margin-top: 1rem;">
+        {{ account.balance }} {{ account.currency }}
+    </p>
+</div>
+
+<div class="card">
+    <h2>Deposit</h2>
+    <form method="post" action="/accounts/{{ account.id }}/deposit" class="inline-form">
+        <div class="form-group">
+            <label for="deposit_amount">Amount</label>
+            <input type="number" id="deposit_amount" name="amount" min="1" value="100" required>
+        </div>
+        <button type="submit" class="btn btn-success">Deposit</button>
+    </form>
+</div>
+
+<div class="card">
+    <h2>Withdraw</h2>
+    <form method="post" action="/accounts/{{ account.id }}/withdraw" class="inline-form">
+        <div class="form-group">
+            <label for="withdraw_amount">Amount</label>
+            <input type="number" id="withdraw_amount" name="amount" min="1" value="100" required>
+        </div>
+        <button type="submit" class="btn btn-danger">Withdraw</button>
+    </form>
+</div>
+
+<div class="card">
+    <h2>Transfer</h2>
+    <form method="post" action="/accounts/{{ account.id }}/transfer">
+        <div class="form-group">
+            <label for="to_account_id">To Account</label>
+            <select id="to_account_id" name="to_account_id" required>
+                <option value="">Select account...</option>
+                {% for other in accounts %}
+                {% if other.id != account.id %}
+                <option value="{{ other.id }}">{{ other.id[..8] }}... ({{ other.balance }} {{ other.currency }})</option>
+                {% endif %}
+                {% endfor %}
+            </select>
+        </div>
+        <div class="form-group">
+            <label for="transfer_amount">Amount</label>
+            <input type="number" id="transfer_amount" name="amount" min="1" value="100" required>
+        </div>
+        <button type="submit" class="btn">Transfer</button>
+    </form>
+</div>
+
+<p style="margin-top: 1rem;">
+    <a href="/accounts" class="btn" style="background: #6b7280;">Back to Accounts</a>
+</p>
+{% endblock %}

--- a/examples/bank-axum-fjall/templates/base.html
+++ b/examples/bank-axum-fjall/templates/base.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Bank{% endblock %}</title>
+    <style>
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            line-height: 1.6;
+            background: #f5f5f5;
+            color: #333;
+        }
+        .container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        header {
+            background: #2563eb;
+            color: white;
+            padding: 1rem;
+            margin-bottom: 2rem;
+        }
+        header h1 {
+            font-size: 1.5rem;
+        }
+        header nav {
+            margin-top: 0.5rem;
+        }
+        header a {
+            color: white;
+            text-decoration: none;
+            margin-right: 1rem;
+        }
+        header a:hover {
+            text-decoration: underline;
+        }
+        .card {
+            background: white;
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin-bottom: 1rem;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .card h2 {
+            margin-bottom: 1rem;
+            color: #1f2937;
+        }
+        .btn {
+            display: inline-block;
+            padding: 0.5rem 1rem;
+            background: #2563eb;
+            color: white;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            text-decoration: none;
+            font-size: 0.875rem;
+        }
+        .btn:hover {
+            background: #1d4ed8;
+        }
+        .btn-success {
+            background: #16a34a;
+        }
+        .btn-success:hover {
+            background: #15803d;
+        }
+        .btn-danger {
+            background: #dc2626;
+        }
+        .btn-danger:hover {
+            background: #b91c1c;
+        }
+        .form-group {
+            margin-bottom: 1rem;
+        }
+        .form-group label {
+            display: block;
+            margin-bottom: 0.25rem;
+            font-weight: 500;
+        }
+        .form-group input, .form-group select {
+            width: 100%;
+            padding: 0.5rem;
+            border: 1px solid #d1d5db;
+            border-radius: 4px;
+            font-size: 1rem;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        th, td {
+            padding: 0.75rem;
+            text-align: left;
+            border-bottom: 1px solid #e5e7eb;
+        }
+        th {
+            background: #f9fafb;
+            font-weight: 600;
+        }
+        .balance {
+            font-size: 2rem;
+            font-weight: bold;
+            color: #16a34a;
+        }
+        .balance.negative {
+            color: #dc2626;
+        }
+        .inline-form {
+            display: flex;
+            gap: 0.5rem;
+            align-items: end;
+        }
+        .inline-form .form-group {
+            margin-bottom: 0;
+            flex: 1;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <div class="container">
+            <h1>Evento Bank</h1>
+            <nav>
+                <a href="/">Home</a>
+                <a href="/accounts">Accounts</a>
+                <a href="/accounts/new">New Account</a>
+            </nav>
+        </div>
+    </header>
+    <main class="container">
+        {% block content %}{% endblock %}
+    </main>
+</body>
+</html>

--- a/examples/bank-axum-fjall/templates/index.html
+++ b/examples/bank-axum-fjall/templates/index.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block title %}Home - Evento Bank{% endblock %}
+
+{% block content %}
+<div class="card">
+    <h2>Welcome to Evento Bank</h2>
+    <p>A demo application showcasing:</p>
+    <ul style="margin: 1rem 0; padding-left: 1.5rem;">
+        <li><strong>Evento</strong> - Event sourcing library</li>
+        <li><strong>Axum</strong> - Web framework</li>
+        <li><strong>Askama</strong> - Type-safe templates</li>
+        <li><strong>Fjall</strong> - Embedded LSM-tree key-value store</li>
+    </ul>
+    <p style="margin-top: 1rem;">
+        <a href="/accounts/new" class="btn">Create Your First Account</a>
+        <a href="/accounts" class="btn" style="background: #6b7280;">View Accounts</a>
+    </p>
+</div>
+
+<div class="card">
+    <h2>How It Works</h2>
+    <p>This application uses event sourcing to track all changes to bank accounts:</p>
+    <ol style="margin: 1rem 0; padding-left: 1.5rem;">
+        <li>Every action (deposit, withdrawal, transfer) creates an event</li>
+        <li>Events are stored in Fjall and never deleted</li>
+        <li>Account state is rebuilt by replaying events</li>
+        <li>Full audit trail is maintained automatically</li>
+    </ol>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Migrate `evento-fjall` to fjall 3.1's `Database`/`Keyspace` API (was `Keyspace`/`Partition`); fix iterator `Guard` handling and `Slice` deref.
- Implement `get_snapshot`/`save_snapshot`/`delete_snapshot` via a dedicated `snapshots` keyspace with revision-checked reads, mirroring `evento-sql`.
- Add `rw` feature + `RwFjall` alias on `evento-fjall`; expose a `fjall` feature on the `evento` crate that re-exports `evento-fjall` (parallel to `sqlite`/`mysql`/`postgres`).
- Wire `make test.fjall` into the CI matrix.

## Test plan
- [x] `cargo test --all-features -p evento-fjall` — 4 unit + 15 integration tests pass.
- [x] `cargo build --all-features` for the full workspace.
- [x] `cargo build -p evento --features fjall` exercises the new feature wiring.
- [x] New `test_snapshot_lifecycle` covers save/get/revision-mismatch/overwrite/delete/idempotent-delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)