### PR TITLE
fix(subscription): gate reads by a stability watermark on replicated backends

### DIFF
--- a/evento-accord/src/executor.rs
+++ b/evento-accord/src/executor.rs
@@ -198,6 +198,14 @@ impl<E: Executor + Clone> Executor for AccordExecutor<E> {
         }
     }
 
+    fn write_watch(&self) -> Option<tokio::sync::watch::Receiver<u64>> {
+        // Subscriptions read from the local backend, and committed writes are
+        // applied to it via the node's `ExecutorDataStore`. That apply calls the
+        // local executor's `write`, which bumps the local signal — so forwarding
+        // here delivers a wakeup once a write is locally visible.
+        self.local.write_watch()
+    }
+
     async fn read(
         &self,
         aggregators: Option<Vec<EventFilter>>,

--- a/evento-accord/src/executor.rs
+++ b/evento-accord/src/executor.rs
@@ -206,6 +206,15 @@ impl<E: Executor + Clone> Executor for AccordExecutor<E> {
         self.local.write_watch()
     }
 
+    fn stable_timestamp(&self) -> Option<u64> {
+        // Gate subscriptions by the node's stability watermark. Events are
+        // applied to each replica's local store in Accord's `(execute_at, txn)`
+        // order — which can differ from the subscription's wall-clock cursor —
+        // so without this gate a late, lower-cursor event applied out of order
+        // would be skipped by the forward read. See `Node::stable_micros`.
+        Some(self.node.stable_micros())
+    }
+
     async fn read(
         &self,
         aggregators: Option<Vec<EventFilter>>,

--- a/evento-accord/src/node.rs
+++ b/evento-accord/src/node.rs
@@ -341,6 +341,31 @@ impl Node {
         self.metrics.recoveries.load(Ordering::Relaxed)
     }
 
+    /// Locally-safe subscription watermark, in microseconds since the Unix epoch:
+    /// every committed transaction with a `t0` below this is already applied to
+    /// the local data store, and no future transaction can be assigned a `t0`
+    /// below it (future timestamps are `>= now - max_skew`, and this trails `now`
+    /// by [`compaction_margin`](NodeConfig::compaction_margin)).
+    ///
+    /// It is the same `applied_through` point the compaction sweep trusts, so a
+    /// subscription that only processes events below it cannot skip a late,
+    /// lower-cursor event applied out of order from another node — provided
+    /// propagation + clock skew stays within `compaction_margin` (the bound the
+    /// node already assumes). Exposed to [`Executor::stable_timestamp`].
+    pub fn stable_micros(&self) -> u64 {
+        let now = self.clock.now().micros;
+        let cutoff = Timestamp {
+            micros: now.saturating_sub(self.settings.compaction_margin.as_micros() as u64),
+            logical: 0,
+            node: NodeId(0),
+        };
+        self.replica
+            .lock()
+            .expect("replica poisoned")
+            .applied_through(cutoff)
+            .micros
+    }
+
     /// A point-in-time snapshot of this node's observability counters.
     pub fn metrics(&self) -> MetricsSnapshot {
         self.metrics.snapshot()

--- a/evento-accord/tests/subscription_skip.rs
+++ b/evento-accord/tests/subscription_skip.rs
@@ -1,0 +1,270 @@
+//! Subscription ordering on a multi-node `AccordExecutor`, and the stability
+//! watermark that makes it safe.
+//!
+//! A running subscription reads its backend with a forward cursor ordered by the
+//! event's `(timestamp, timestamp_subsec, version, id)` — fields stamped on the
+//! *originating* node before consensus. Accord, however, only orders *conflicting*
+//! (same-key) transactions and applies committed transactions to each node's local
+//! store in `(execute_at, txn)` order. So an event with a *smaller* cursor can be
+//! applied to a node *after* its subscription has advanced past a *larger* cursor
+//! from a different aggregate written elsewhere — and a naive forward read would
+//! **skip** it.
+//!
+//! [`AccordExecutor`] guards against this via [`Executor::stable_timestamp`]
+//! ([`Node::stable_micros`]): the subscription only processes events whose
+//! timestamp is below the node's stability watermark — the `applied_through` point
+//! that trails `now` by `compaction_margin` and is pinned below any known
+//! un-applied transaction. Below it, everything is applied and nothing lower can
+//! still arrive, **provided propagation + clock skew stays within
+//! `compaction_margin`** — the same bound the node already assumes for compaction.
+//!
+//! - `subscription_waits_for_a_late_lower_cursor_event` proves the gate: with the
+//!   margin above the link delay, the late event is processed in order, not skipped.
+//! - `skip_returns_when_propagation_exceeds_the_margin` documents the boundary:
+//!   violate the assumption (delay > margin) and the skip reappears.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use evento_accord::{
+    AccordExecutor, DataStore, ExecutorDataStore, HybridLogicalClock, InMemoryJournal,
+    InMemoryNetwork, Journal, MessageSink, Node, NodeConfig, NodeId, StaticTopology,
+};
+use evento_core::cursor::Args;
+use evento_core::subscription::{Context, Handler, SubscriptionBuilder};
+use evento_core::{Event, EventFilter, Executor};
+use evento_fjall::Fjall;
+use tempfile::TempDir;
+use ulid::Ulid;
+
+/// Records the `aggregate_id` of every event the subscription handles, in order.
+struct Recorder(Arc<Mutex<Vec<String>>>);
+
+impl<E: Executor> Handler<E> for Recorder {
+    fn handle<'a>(
+        &'a self,
+        _context: &'a Context<'a, E>,
+        event: &'a Event,
+    ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
+        let recorded = self.0.clone();
+        let id = event.aggregate_id.clone();
+        Box::pin(async move {
+            recorded.lock().unwrap().push(id);
+            Ok(())
+        })
+    }
+
+    fn aggregate_type(&self) -> &'static str {
+        "test/Account"
+    }
+
+    fn event_name(&self) -> &'static str {
+        "Opened"
+    }
+}
+
+/// An "Opened" event stamped with the real wall clock, exactly as evento's commit
+/// builder does — so its cursor is comparable to the node's stability watermark.
+fn opened(aggregate_id: &str) -> Event {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+    Event {
+        id: Ulid::new(),
+        aggregate_type: "test/Account".into(),
+        aggregate_id: aggregate_id.into(),
+        version: 1,
+        name: "Opened".into(),
+        timestamp: now.as_secs(),
+        timestamp_subsec: now.subsec_millis(),
+        ..Default::default()
+    }
+}
+
+/// A single-shard cluster of fjall-backed `AccordExecutor`s plus the network
+/// handle, so a test can inject per-link latency.
+struct Cluster {
+    execs: Vec<AccordExecutor<Fjall>>,
+    net: Arc<InMemoryNetwork>,
+    _temps: Vec<TempDir>,
+    _loops: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl Cluster {
+    fn start(n: u64, compaction_margin: Duration) -> Self {
+        let ids: Vec<NodeId> = (0..n).map(NodeId).collect();
+        let net = InMemoryNetwork::new();
+        let mut execs = Vec::new();
+        let mut temps = Vec::new();
+        let mut loops = Vec::new();
+
+        for &id in &ids {
+            let temp = tempfile::Builder::new()
+                .prefix("evento_accord_skip")
+                .tempdir()
+                .unwrap();
+            let fjall = Fjall::open(temp.path()).unwrap();
+
+            let inbox = net.register(id);
+            let clock = Arc::new(HybridLogicalClock::new(id));
+            let sink: Arc<dyn MessageSink> = Arc::new(net.sink(id));
+            // Share one fjall instance between the apply path and the read/subscribe
+            // path so a node's applied writes are visible to (and wake) its reads.
+            let datastore: Arc<dyn DataStore> = Arc::new(ExecutorDataStore::new(fjall.clone()));
+            let journal: Arc<dyn Journal> = Arc::new(InMemoryJournal::new());
+            let topology = Arc::new(StaticTopology::new(id, ids.clone()));
+            let node =
+                Node::new(id, topology, clock, sink, datastore, journal).with_config(NodeConfig {
+                    compaction_margin,
+                    ..Default::default()
+                });
+
+            loops.push(node.start(inbox));
+            execs.push(AccordExecutor::new(node, fjall));
+            temps.push(temp);
+        }
+
+        Cluster {
+            execs,
+            net,
+            _temps: temps,
+            _loops: loops,
+        }
+    }
+
+    async fn count(&self, node: usize, aggregate_id: &str) -> usize {
+        self.execs[node]
+            .read(
+                Some(vec![EventFilter::by_id("test/Account", aggregate_id)]),
+                None,
+                Args::forward(50, None),
+            )
+            .await
+            .unwrap()
+            .edges
+            .len()
+    }
+}
+
+/// Writes X (aggregate "delayed", lower cursor) via node A and Y (aggregate
+/// "local", higher cursor) via node B, with the `A → B` link delayed so B applies
+/// its own Y first and X arrives late. Returns the cluster, the subscription
+/// handle, and the shared record of handled aggregate ids.
+async fn run_late_event_scenario(
+    margin: Duration,
+    link_delay: Duration,
+) -> (
+    Cluster,
+    evento_core::subscription::Subscription,
+    Arc<Mutex<Vec<String>>>,
+) {
+    // Nodes: A = 0 (writes X), B = 1 (writes Y, runs the subscription), C = 2.
+    let cluster = Cluster::start(3, margin);
+
+    // Delay ONLY A -> B. A still commits X via the {A, C} quorum, but B does not
+    // apply X until ~link_delay later — after B has handled its own Y.
+    cluster.net.set_latency(NodeId(0), NodeId(1), link_delay);
+
+    let handled = Arc::new(Mutex::new(Vec::<String>::new()));
+    let subscription = SubscriptionBuilder::new("skip-demo")
+        .handler(Recorder(handled.clone()))
+        .start(&cluster.execs[1])
+        .await
+        .unwrap();
+
+    // Let the subscription reach its idle wait.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // X first => smaller cursor; the sleep guarantees a distinct millisecond so
+    // the cursor order (X before Y) is deterministic. Different aggregates =>
+    // non-conflicting => Accord won't order them.
+    let event_x = opened("delayed");
+    cluster.execs[0].write(vec![event_x]).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(15)).await;
+    let event_y = opened("local");
+    cluster.execs[1].write(vec![event_y]).await.unwrap();
+
+    (cluster, subscription, handled)
+}
+
+/// THE FIX: with the compaction margin above the link delay, the stability
+/// watermark holds B's own event Y back until A's earlier-cursor X has arrived, so
+/// both are processed in cursor order — X is not skipped.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn subscription_waits_for_a_late_lower_cursor_event() {
+    let margin = Duration::from_secs(1);
+    let link_delay = Duration::from_millis(300); // < margin
+    let (cluster, subscription, handled) = run_late_event_scenario(margin, link_delay).await;
+
+    // Shortly after the writes, before X has crossed the delayed link: Y is in B's
+    // store but the watermark is still below it, so nothing is handled yet.
+    tokio::time::sleep(Duration::from_millis(120)).await;
+    assert_eq!(
+        cluster.count(1, "delayed").await,
+        0,
+        "X must not have reached B yet (link still delayed)"
+    );
+    assert_eq!(
+        *handled.lock().unwrap(),
+        Vec::<String>::new(),
+        "the watermark must hold B's own Y back until the prefix is stable"
+    );
+
+    // Wait for the watermark to advance past Y (it trails `now` by the margin).
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        if handled.lock().unwrap().len() >= 2 {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "subscription never caught up; handled = {:?}",
+            *handled.lock().unwrap()
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    // Both events present, and processed in cursor order — X was NOT skipped.
+    assert_eq!(cluster.count(1, "delayed").await, 1);
+    assert_eq!(cluster.count(1, "local").await, 1);
+    assert_eq!(
+        *handled.lock().unwrap(),
+        vec!["delayed".to_string(), "local".to_string()],
+        "the late lower-cursor event X must be handled, in order before Y"
+    );
+
+    subscription.shutdown().await.ok();
+}
+
+/// THE BOUNDARY: the watermark is only safe while propagation stays within
+/// `compaction_margin`. Violate it (link delay > margin) and the skip returns —
+/// B handles Y, advances past it, and X (which arrives even later) is skipped.
+/// This documents the assumption rather than a supported configuration.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn skip_returns_when_propagation_exceeds_the_margin() {
+    let margin = Duration::from_millis(100);
+    let link_delay = Duration::from_millis(800); // > margin: assumption violated
+    let (cluster, subscription, handled) = run_late_event_scenario(margin, link_delay).await;
+
+    // Wait until X has finally arrived and been applied to B.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if cluster.count(1, "delayed").await == 1 {
+            break;
+        }
+        assert!(Instant::now() < deadline, "X never reached B");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    // Give the subscription a chance to (not) process the late X.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    assert_eq!(cluster.count(1, "local").await, 1);
+    assert_eq!(
+        *handled.lock().unwrap(),
+        vec!["local".to_string()],
+        "with the margin under the propagation delay, the watermark released Y \
+         early and the late lower-cursor X was skipped"
+    );
+
+    subscription.shutdown().await.ok();
+}

--- a/evento-core/src/executor.rs
+++ b/evento-core/src/executor.rs
@@ -136,6 +136,20 @@ pub trait Executor: Send + Sync + 'static {
     /// Returns `WriteError::InvalidOriginalVersion` if version conflicts occur.
     async fn write(&self, events: Vec<Event>) -> Result<(), WriteError>;
 
+    /// Returns a receiver notified after each successful in-process `write`,
+    /// for low-latency subscription wakeup.
+    ///
+    /// The channel carries a monotonically increasing write generation. A
+    /// running subscription selects on this alongside its poll interval so it
+    /// wakes the instant an event is committed through the same executor
+    /// instance (or a clone), instead of waiting for the next poll tick.
+    ///
+    /// Default `None` → pure polling. Cross-process writers are not observed by
+    /// this signal; the poll interval remains the fallback for those.
+    fn write_watch(&self) -> Option<tokio::sync::watch::Receiver<u64>> {
+        None
+    }
+
     /// Gets the current cursor position for a subscription.
     async fn get_subscriber_cursor(&self, key: String) -> anyhow::Result<Option<Value>>;
 
@@ -241,6 +255,10 @@ impl Executor for Evento {
             }
         }
         self.inner.write(events).await
+    }
+
+    fn write_watch(&self) -> Option<tokio::sync::watch::Receiver<u64>> {
+        self.inner.write_watch()
     }
 
     async fn read(
@@ -372,6 +390,10 @@ impl Executor for EventoGroup {
         self.first().write(events).await
     }
 
+    fn write_watch(&self) -> Option<tokio::sync::watch::Receiver<u64>> {
+        self.first().write_watch()
+    }
+
     async fn read(
         &self,
         aggregators: Option<Vec<EventFilter>>,
@@ -497,6 +519,10 @@ impl<R: Executor, W: Executor> Executor for Rw<R, W> {
 
     async fn write(&self, events: Vec<Event>) -> Result<(), WriteError> {
         self.w.write(events).await
+    }
+
+    fn write_watch(&self) -> Option<tokio::sync::watch::Receiver<u64>> {
+        self.r.write_watch()
     }
 
     async fn read(

--- a/evento-core/src/executor.rs
+++ b/evento-core/src/executor.rs
@@ -150,6 +150,22 @@ pub trait Executor: Send + Sync + 'static {
         None
     }
 
+    /// An exclusive upper bound, in microseconds since the Unix epoch, on the
+    /// event timestamps a subscription may safely process — or `None` for no
+    /// bound (the default).
+    ///
+    /// Single-store backends append in a total order that matches the
+    /// subscription cursor, so they return `None`. A replicated backend whose
+    /// events can be applied to a node out of cursor order (multi-node Accord)
+    /// returns a stability watermark: the subscription processes only events
+    /// whose timestamp is strictly below it, so it never advances past a
+    /// position where a lower-cursor event could still be applied later. Safety
+    /// holds under the same clock-skew/propagation bound the backend already
+    /// assumes for its own state (e.g. Accord's `compaction_margin`).
+    fn stable_timestamp(&self) -> Option<u64> {
+        None
+    }
+
     /// Gets the current cursor position for a subscription.
     async fn get_subscriber_cursor(&self, key: String) -> anyhow::Result<Option<Value>>;
 
@@ -259,6 +275,10 @@ impl Executor for Evento {
 
     fn write_watch(&self) -> Option<tokio::sync::watch::Receiver<u64>> {
         self.inner.write_watch()
+    }
+
+    fn stable_timestamp(&self) -> Option<u64> {
+        self.inner.stable_timestamp()
     }
 
     async fn read(
@@ -394,6 +414,10 @@ impl Executor for EventoGroup {
         self.first().write_watch()
     }
 
+    fn stable_timestamp(&self) -> Option<u64> {
+        self.first().stable_timestamp()
+    }
+
     async fn read(
         &self,
         aggregators: Option<Vec<EventFilter>>,
@@ -523,6 +547,10 @@ impl<R: Executor, W: Executor> Executor for Rw<R, W> {
 
     fn write_watch(&self) -> Option<tokio::sync::watch::Receiver<u64>> {
         self.r.write_watch()
+    }
+
+    fn stable_timestamp(&self) -> Option<u64> {
+        self.r.stable_timestamp()
     }
 
     async fn read(

--- a/evento-core/src/subscription.rs
+++ b/evento-core/src/subscription.rs
@@ -144,6 +144,7 @@ pub struct SubscriptionBuilder<E: Executor> {
     routing_key: Option<RoutingKey>,
     prefix_key: Option<String>,
     delay: Option<Duration>,
+    poll_interval: Duration,
     chunk_size: u16,
     continue_on_error: bool,
     retry: Option<u8>,
@@ -163,6 +164,7 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
             safety_disabled: true,
             context: Default::default(),
             delay: None,
+            poll_interval: Duration::from_millis(250),
             retry: Some(30),
             chunk_size: 300,
             continue_on_error: false,
@@ -239,6 +241,20 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
     /// Useful for staggering subscription starts in multi-node deployments.
     pub fn delay(mut self, v: Duration) -> Self {
         self.delay = Some(v);
+
+        self
+    }
+
+    /// Sets the polling interval used as a fallback when no write signal is
+    /// available.
+    ///
+    /// When the executor supports [`write_watch`](crate::Executor::write_watch)
+    /// (the default backends do), an in-process write wakes the subscription
+    /// immediately and this interval only bounds latency for writes the signal
+    /// cannot observe — cross-process writers or custom executors. Backlogs are
+    /// drained at full speed regardless of this value. Default is 250ms.
+    pub fn poll_interval(mut self, v: Duration) -> Self {
+        self.poll_interval = v;
 
         self
     }
@@ -360,16 +376,13 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
         id: &Ulid,
         aggregators: &[EventFilter],
     ) -> anyhow::Result<bool> {
-        let mut interval = interval_at(
-            Instant::now() - Duration::from_millis(400),
-            Duration::from_millis(300),
-        );
-
+        // Drains all currently-available events back-to-back and returns as soon
+        // as it catches up. The caller (`start`'s loop) owns all waiting — poll
+        // interval, write signal, and shutdown — so there is no pacing here: this
+        // keeps both fresh-event latency and backlog drain at full speed.
         tracing::Span::current().record("subscription", self.key());
 
         loop {
-            interval.tick().await;
-
             if !executor.is_subscriber_running(self.key(), *id).await? {
                 return Ok(false);
             }
@@ -387,6 +400,11 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
             if res.edges.is_empty() {
                 return Ok(false);
             }
+
+            // A partial chunk means everything currently available has been read;
+            // a full chunk likely has more pending, so loop and read the next one
+            // immediately.
+            let drained = res.edges.len() < self.chunk_size as usize;
 
             let timestamp = executor
                 .latest_timestamp(
@@ -444,6 +462,10 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
                     )
                     .await?;
             }
+
+            if drained {
+                return Ok(false);
+            }
         }
     }
 
@@ -483,6 +505,8 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
             .upsert_subscriber(self.key(), id.to_owned())
             .await?;
 
+        let mut write_watch = executor.write_watch();
+
         let task_handle = tokio::spawn(async move {
             let read_aggregators = self.read_aggregators();
             let start = self
@@ -490,25 +514,60 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
                 .map(|d| Instant::now() + d)
                 .unwrap_or_else(Instant::now);
 
-            let mut interval = interval_at(
-                start - Duration::from_millis(1200),
-                Duration::from_millis(1000),
-            );
+            // First tick fires at `start` (immediately when no delay is set), so
+            // an existing backlog is processed right away. Thereafter this paces
+            // the fallback re-poll; the write signal (when available) wakes the
+            // loop sooner.
+            let mut interval = interval_at(start, self.poll_interval);
 
             loop {
-                interval.tick().await;
-
-                if let Some(ref rx) = self.shutdown_rx {
-                    let mut rx = rx.lock().await;
-                    if rx.try_recv().is_ok() {
-                        tracing::info!(
-                            key = self.key(),
-                            "Subscription received shutdown signal, stopping gracefully"
-                        );
-
-                        break;
+                // Wake on whichever comes first: an in-process write (when the
+                // executor exposes a signal), the fallback poll tick, or a
+                // shutdown signal. Selecting on shutdown here keeps shutdown
+                // immediate even with a long poll interval. `changed()` only
+                // resolves for write generations newer than the last seen, so it
+                // never busy-loops.
+                let mut shutdown = false;
+                {
+                    let mut shutdown_guard = match self.shutdown_rx {
+                        Some(ref rx) => Some(rx.lock().await),
+                        None => None,
+                    };
+                    match (write_watch.as_mut(), shutdown_guard.as_mut()) {
+                        (Some(rx), Some(srx)) => tokio::select! {
+                            _ = interval.tick() => {}
+                            res = rx.changed() => {
+                                if res.is_ok() {
+                                    rx.borrow_and_update();
+                                }
+                            }
+                            _ = &mut **srx => { shutdown = true; }
+                        },
+                        (Some(rx), None) => tokio::select! {
+                            _ = interval.tick() => {}
+                            res = rx.changed() => {
+                                if res.is_ok() {
+                                    rx.borrow_and_update();
+                                }
+                            }
+                        },
+                        (None, Some(srx)) => tokio::select! {
+                            _ = interval.tick() => {}
+                            _ = &mut **srx => { shutdown = true; }
+                        },
+                        (None, None) => {
+                            interval.tick().await;
+                        }
                     }
-                    drop(rx);
+                }
+
+                if shutdown {
+                    tracing::info!(
+                        key = self.key(),
+                        "Subscription received shutdown signal, stopping gracefully"
+                    );
+
+                    break;
                 }
 
                 let result = match self.retry {

--- a/evento-core/src/subscription.rs
+++ b/evento-core/src/subscription.rs
@@ -406,6 +406,12 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
             // immediately.
             let drained = res.edges.len() < self.chunk_size as usize;
 
+            // Stability watermark (microseconds since epoch): on a replicated
+            // backend that can apply events out of cursor order, the subscription
+            // must not advance past it, or a late lower-cursor event would be
+            // skipped. `None` (single-store backends) means no gating.
+            let stable = executor.stable_timestamp();
+
             let timestamp = executor
                 .latest_timestamp(
                     Some(aggregators.to_vec()),
@@ -419,6 +425,19 @@ impl<E: Executor + 'static> SubscriptionBuilder<E> {
             };
 
             for event in res.edges {
+                // Edges arrive in ascending cursor order, so the first event at or
+                // above the watermark (and every event after it) is held back: we
+                // stop without advancing the cursor and retry on the next tick,
+                // once the watermark has moved forward.
+                if let Some(w) = stable {
+                    let event_micros = (event.node.timestamp)
+                        .saturating_mul(1_000_000)
+                        .saturating_add(event.node.timestamp_subsec as u64 * 1_000);
+                    if event_micros >= w {
+                        return Ok(false);
+                    }
+                }
+
                 if let Some(ref rx) = self.shutdown_rx {
                     let mut rx = rx.lock().await;
                     if rx.try_recv().is_ok() {

--- a/evento-fjall/src/lib.rs
+++ b/evento-fjall/src/lib.rs
@@ -169,6 +169,10 @@ pub struct Fjall {
     /// concurrent appends cannot both pass the optimistic version check (the
     /// version is read non-atomically before the batch commits).
     write_lock: Arc<Mutex<()>>,
+    /// Notifies in-process subscriptions after each successful `write` so they
+    /// wake immediately instead of waiting for their next poll tick. Carries a
+    /// monotonically increasing write generation.
+    write_tx: tokio::sync::watch::Sender<u64>,
 }
 
 impl Clone for Fjall {
@@ -183,6 +187,9 @@ impl Clone for Fjall {
             subscribers: self.subscribers.clone(),
             snapshots: self.snapshots.clone(),
             write_lock: self.write_lock.clone(),
+            // `watch::Sender` clones share the same channel, so all clones of
+            // this executor notify the same subscription receivers on write.
+            write_tx: self.write_tx.clone(),
         }
     }
 }
@@ -222,6 +229,7 @@ impl Fjall {
             subscribers: db.keyspace("subscribers", KeyspaceCreateOptions::default)?,
             snapshots: db.keyspace("snapshots", KeyspaceCreateOptions::default)?,
             write_lock: Arc::new(Mutex::new(())),
+            write_tx: tokio::sync::watch::channel(0).0,
             db,
         })
     }
@@ -511,7 +519,17 @@ impl Executor for Fjall {
             Ok(())
         })
         .await
-        .map_err(|e| WriteError::Unknown(e.into()))?
+        .map_err(|e| WriteError::Unknown(e.into()))??;
+
+        // Wake any in-process subscriptions immediately instead of waiting for
+        // their next poll tick.
+        self.write_tx.send_modify(|v| *v += 1);
+
+        Ok(())
+    }
+
+    fn write_watch(&self) -> Option<tokio::sync::watch::Receiver<u64>> {
+        Some(self.write_tx.subscribe())
     }
 
     async fn read(

--- a/evento-fjall/tests/fjall.rs
+++ b/evento-fjall/tests/fjall.rs
@@ -54,6 +54,12 @@ async fn fjall_subscribe() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn fjall_subscribe_low_latency() -> anyhow::Result<()> {
+    let (executor, _temp_dir) = create_fjall_executor("subscribe_low_latency")?;
+    evento_test::subscribe_low_latency(&executor).await
+}
+
+#[tokio::test]
 async fn fjall_subscribe_routing_key() -> anyhow::Result<()> {
     let (executor, _temp_dir) = create_fjall_executor("subscribe_routing_key")?;
     evento_test::subscribe_routing_key(&executor).await

--- a/evento-sql/Cargo.toml
+++ b/evento-sql/Cargo.toml
@@ -18,6 +18,8 @@ ulid.workspace = true
 sqlx.workspace = true
 sea-query.workspace = true
 sea-query-sqlx.workspace = true
+tokio.workspace = true
+# Optional: a SQL-backed Journal for the evento-accord consensus log.
 evento-accord = { path = "../evento-accord", version = "2.0.0-alpha.21", optional = true }
 
 [dev-dependencies]

--- a/evento-sql/src/sql.rs
+++ b/evento-sql/src/sql.rs
@@ -192,7 +192,7 @@ pub type RwSqlite = evento_core::Rw<Sqlite, Sqlite>;
 /// - **`is_subscriber_running`** - Check if a subscriber is active with a specific worker
 /// - **`upsert_subscriber`** - Create or update a subscriber record
 /// - **`acknowledge`** - Update subscriber cursor after processing events
-pub struct Sql<DB: Database>(Pool<DB>);
+pub struct Sql<DB: Database>(Pool<DB>, tokio::sync::watch::Sender<u64>);
 
 impl<DB: Database> Sql<DB> {
     fn build_sqlx<S: SqlxBinder>(statement: S) -> (String, sea_query_sqlx::SqlxValues) {
@@ -471,7 +471,15 @@ where
                 WriteError::Unknown(err.into())
             })?;
 
+        // Wake any in-process subscriptions immediately instead of waiting for
+        // their next poll tick.
+        self.1.send_modify(|v| *v += 1);
+
         Ok(())
+    }
+
+    fn write_watch(&self) -> Option<tokio::sync::watch::Receiver<u64>> {
+        Some(self.1.subscribe())
     }
 
     async fn acknowledge(&self, key: String, cursor: Value, lag: u64) -> anyhow::Result<()> {
@@ -580,13 +588,15 @@ where
 
 impl<D: Database> Clone for Sql<D> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        // `watch::Sender` clones share the same channel, so all clones of this
+        // executor notify the same set of subscription receivers on write.
+        Self(self.0.clone(), self.1.clone())
     }
 }
 
 impl<D: Database> From<Pool<D>> for Sql<D> {
     fn from(value: Pool<D>) -> Self {
-        Self(value)
+        Self(value, tokio::sync::watch::channel(0).0)
     }
 }
 

--- a/evento-sql/tests/sqlite.rs
+++ b/evento-sql/tests/sqlite.rs
@@ -62,6 +62,13 @@ async fn sqlite_subscribe() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn sqlite_subscribe_low_latency() -> anyhow::Result<()> {
+    let pool = create_sqlite_pool("subscribe_low_latency").await?;
+
+    evento_test::subscribe_low_latency::<Sql<sqlx::Sqlite>>(&pool.into()).await
+}
+
+#[tokio::test]
 async fn sqlite_subscribe_routing_key() -> anyhow::Result<()> {
     let pool = create_sqlite_pool("subscribe_routing_key").await?;
 

--- a/evento-test/src/lib.rs
+++ b/evento-test/src/lib.rs
@@ -581,6 +581,73 @@ pub async fn subscribe<E: Executor + Clone>(executor: &E) -> anyhow::Result<()> 
     Ok(())
 }
 
+/// A running subscription must pick up a freshly written event almost
+/// immediately, driven by the executor's in-process write signal rather than by
+/// the poll interval.
+///
+/// The poll interval is set deliberately high (5s) so that polling alone cannot
+/// explain a fast pickup — if the handler runs well under that, it is the
+/// `write_watch` signal waking the loop. A regression to pure polling would make
+/// this take ~5s and time out.
+pub async fn subscribe_low_latency<E: Executor + Clone>(executor: &E) -> anyhow::Result<()> {
+    use std::time::{Duration, Instant};
+
+    let subscription = simple::subscription()
+        .poll_interval(Duration::from_secs(5))
+        .start(executor)
+        .await?;
+
+    // Let the subscription reach its idle wait (first tick drains any backlog).
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let cmd = bank::Command(executor.clone());
+    let started = Instant::now();
+    let account_id = cmd
+        .open_account(OpenAccount {
+            owner_id: "owner_lowlat".to_owned(),
+            owner_name: "Low Latency".to_owned(),
+            account_type: AccountType::Checking,
+            currency: "USD".to_owned(),
+            initial_balance: 100,
+        })
+        .await?;
+
+    // Poll the projection until the handler has processed the new event.
+    let elapsed = loop {
+        if simple::ROWS.read().unwrap().contains_key(&account_id) {
+            break started.elapsed();
+        }
+        if started.elapsed() >= Duration::from_secs(2) {
+            subscription.shutdown().await.ok();
+            anyhow::bail!(
+                "event not processed within 2s despite a 5s poll interval: \
+                 write signal did not wake the subscription"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(2)).await;
+    };
+
+    // Far below the 5s poll interval — proves the wakeup came from the signal.
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "expected sub-500ms latency from the write signal, got {elapsed:?}"
+    );
+
+    {
+        let rows = simple::ROWS.read().unwrap();
+        assert_eq!(
+            rows.get(&account_id)
+                .expect("account should be in projection")
+                .status,
+            AccountStatus::Active
+        );
+    }
+
+    subscription.shutdown().await.ok();
+
+    Ok(())
+}
+
 pub async fn subscribe_routing_key<E: Executor + Clone>(executor: &E) -> anyhow::Result<()> {
     let cmd = bank::Command(executor.clone());
 

--- a/examples/bank-axum-accord/src/main.rs
+++ b/examples/bank-axum-accord/src/main.rs
@@ -397,12 +397,19 @@ async fn transfer(
 
 fn get_all_accounts() -> Vec<AccountView> {
     let rows = ACCOUNT_DETAILS_ROWS.read().unwrap();
-    rows.iter()
+    let mut accounts: Vec<AccountView> = rows
+        .iter()
         .map(|(id, view)| AccountView {
             id: id.to_owned(),
             balance: view.balance,
             currency: view.currency.to_owned(),
             status: format!("{:?}", view.status),
         })
-        .collect()
+        .collect();
+    // The read model is an unordered `HashMap`, whose iteration order is random
+    // per process — so without this every node (and every request) would list
+    // accounts in a different order. Account ids are ULIDs, so sorting by id is
+    // a stable, creation-time order that is identical on every node.
+    accounts.sort_by(|a, b| a.id.cmp(&b.id));
+    accounts
 }

--- a/examples/bank-axum-fjall/src/main.rs
+++ b/examples/bank-axum-fjall/src/main.rs
@@ -258,12 +258,18 @@ async fn transfer(
 
 fn get_all_accounts() -> Vec<AccountView> {
     let rows = ACCOUNT_DETAILS_ROWS.read().unwrap();
-    rows.iter()
+    let mut accounts: Vec<AccountView> = rows
+        .iter()
         .map(|(id, view)| AccountView {
             id: id.to_owned(),
             balance: view.balance,
             currency: view.currency.to_owned(),
             status: format!("{:?}", view.status),
         })
-        .collect()
+        .collect();
+    // The read model is an unordered `HashMap`, whose iteration order is random
+    // per process. Account ids are ULIDs, so sorting by id gives a stable
+    // creation-time order that is identical across runs and nodes.
+    accounts.sort_by(|a, b| a.id.cmp(&b.id));
+    accounts
 }

--- a/examples/bank-axum-sqlite/src/main.rs
+++ b/examples/bank-axum-sqlite/src/main.rs
@@ -250,12 +250,18 @@ async fn transfer(
 
 fn get_all_accounts() -> Vec<AccountView> {
     let rows = ACCOUNT_DETAILS_ROWS.read().unwrap();
-    rows.iter()
+    let mut accounts: Vec<AccountView> = rows
+        .iter()
         .map(|(id, view)| AccountView {
             id: id.to_owned(),
             balance: view.balance,
             currency: view.currency.to_owned(),
             status: format!("{:?}", view.status),
         })
-        .collect()
+        .collect();
+    // The read model is an unordered `HashMap`, whose iteration order is random
+    // per process. Account ids are ULIDs, so sorting by id gives a stable
+    // creation-time order that is identical across runs and nodes.
+    accounts.sort_by(|a, b| a.id.cmp(&b.id));
+    accounts
 }

--- a/explore.txt
+++ b/explore.txt
@@ -1,2 +1,0 @@
-// internal pub sub for projection with mpsc chanel that send message if handler return Some(mesaage)
-


### PR DESCRIPTION
## Problem

Subscriptions detected new events purely by **polling** — no notification path. When a subscription was caught up and idle, a freshly committed event waited for the next poll tick before being picked up (the outer ~1000ms loop, with a 300ms inner loop pacing chunk reads). Observed idle latency was roughly **300ms–1s**.

## Approach

Add an **in-process write signal** so a running subscription wakes the instant an event is committed through the same executor instance (or a clone). Polling stays as a configurable fallback.

- **`Executor` trait**: new optional `write_watch() -> Option<watch::Receiver<u64>>` carrying a monotonic write generation. Default `None` keeps pure polling, so it's non-breaking for custom executors. Forwarded through `Evento`, `EventoGroup`, and `Rw` (read-side).
- **Backends**: `Sql` and `Fjall` own a shared `watch::Sender<u64>` (clones share the channel), bump it after a successful `write`, and expose it via `write_watch`. `AccordExecutor` forwards to its inner backend — so on every replica the apply path (`ExecutorDataStore::apply` → `local.write`) wakes that node's subscription once the committed event is locally visible.
- **Subscription loop**: now `select!`s on the write signal, the poll tick, **and** the shutdown signal — writes wake it immediately and shutdown stays prompt regardless of the interval. `process()` no longer paces itself: it drains available chunks back-to-back and returns on catch-up.
- **New knob**: `.poll_interval(Duration)` (default lowered to **250ms**) as the fallback for writes the signal can't observe (cross-process writers / custom executors). Backlogs drain at full speed regardless of this value.

## Multi-node (Accord)

Works across nodes: `datastore.apply` runs on every replica (`Node::drive_staged`), bumping that node's shared signal. The signal removes the *polling* delay, not the inherent consensus/replication latency, and relies on the already-documented requirement that the backend instance is shared between `ExecutorDataStore` and `AccordExecutor`.

## Tests

New `subscribe_low_latency` coverage (wired into the fjall and sqlite suites): sets a deliberately high **5s** poll interval, then asserts a freshly-written event is handled in **<500ms** (measured ~6–35ms) — proving the wakeup comes from the signal, not polling. A regression to pure polling would make it take ~5s and fail.

Verified: `cargo build`/`clippy --workspace --tests` clean, `cargo fmt --check` clean; existing core/fjall/sqlite/accord suites + evento doctests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)