### PR TITLE
fix(subscription): add leading-cursor index for no-routing-key scans

### DIFF
--- a/evento-sql-migrator/src/lib.rs
+++ b/evento-sql-migrator/src/lib.rs
@@ -49,6 +49,7 @@
 //! - [`M0002`] - Adds `timestamp_subsec` column for sub-second precision timestamps
 //! - [`M0003`] - Drops the snapshot table and extends the event name column length
 //! - [`M0004`] - Replaces `idx_event_type` with a composite cursor-scan index
+//! - [`M0005`] - Adds a leading-cursor index for no-routing-key subscription scans
 //!
 //! # Database Schema
 //!
@@ -93,6 +94,7 @@ mod m0001;
 mod m0002;
 mod m0003;
 mod m0004;
+mod m0005;
 
 #[cfg(feature = "accord")]
 pub use accord::AccordMigration;
@@ -100,6 +102,7 @@ pub use m0001::InitMigration;
 pub use m0002::M0002;
 pub use m0003::M0003;
 pub use m0004::M0004;
+pub use m0005::M0005;
 
 /// Creates a new [`Migrator`] instance with all Evento migrations registered.
 ///
@@ -137,12 +140,14 @@ where
     M0002: sqlx_migrator::Migration<DB>,
     M0003: sqlx_migrator::Migration<DB>,
     M0004: sqlx_migrator::Migration<DB>,
+    M0005: sqlx_migrator::Migration<DB>,
 {
     let mut migrator = Migrator::default();
     migrator.add_migration(Box::new(InitMigration))?;
     migrator.add_migration(Box::new(M0002))?;
     migrator.add_migration(Box::new(M0003))?;
     migrator.add_migration(Box::new(M0004))?;
+    migrator.add_migration(Box::new(M0005))?;
     Ok(migrator)
 }
 
@@ -153,6 +158,7 @@ where
     M0002: sqlx_migrator::Migration<DB>,
     M0003: sqlx_migrator::Migration<DB>,
     M0004: sqlx_migrator::Migration<DB>,
+    M0005: sqlx_migrator::Migration<DB>,
     AccordMigration: sqlx_migrator::Migration<DB>,
 {
     let mut migrator = Migrator::default();
@@ -160,6 +166,7 @@ where
     migrator.add_migration(Box::new(M0002))?;
     migrator.add_migration(Box::new(M0003))?;
     migrator.add_migration(Box::new(M0004))?;
+    migrator.add_migration(Box::new(M0005))?;
     // The optional evento-accord consensus-journal tables.
     migrator.add_migration(Box::new(AccordMigration))?;
     Ok(migrator)

--- a/evento-sql-migrator/src/m0005/event/create_type_cursor_idx.rs
+++ b/evento-sql-migrator/src/m0005/event/create_type_cursor_idx.rs
@@ -1,0 +1,99 @@
+use sea_query::{Index, IndexCreateStatement, IndexDropStatement};
+
+use evento_sql::Event;
+
+pub struct Operation;
+
+fn up_statement() -> IndexCreateStatement {
+    Index::create()
+        .name("idx_event_type_cursor")
+        .table(Event::Table)
+        .col(Event::AggregatorType)
+        .col(Event::Timestamp)
+        .col(Event::TimestampSubsec)
+        .col(Event::Version)
+        .col(Event::Id)
+        .to_owned()
+}
+
+fn drop_statement() -> IndexDropStatement {
+    Index::drop()
+        .name("idx_event_type_cursor")
+        .table(Event::Table)
+        .to_owned()
+}
+
+#[cfg(feature = "sqlite")]
+#[async_trait::async_trait]
+impl sqlx_migrator::Operation<sqlx::Sqlite> for Operation {
+    async fn up(
+        &self,
+        connection: &mut sqlx::SqliteConnection,
+    ) -> Result<(), sqlx_migrator::Error> {
+        let statment = up_statement().to_string(sea_query::SqliteQueryBuilder);
+        sqlx::query(sqlx::AssertSqlSafe(statment.as_str()))
+            .execute(connection)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(
+        &self,
+        connection: &mut sqlx::SqliteConnection,
+    ) -> Result<(), sqlx_migrator::Error> {
+        let statment = drop_statement().to_string(sea_query::SqliteQueryBuilder);
+        sqlx::query(sqlx::AssertSqlSafe(statment.as_str()))
+            .execute(connection)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "mysql")]
+#[async_trait::async_trait]
+impl sqlx_migrator::Operation<sqlx::MySql> for Operation {
+    async fn up(&self, connection: &mut sqlx::MySqlConnection) -> Result<(), sqlx_migrator::Error> {
+        let statment = up_statement().to_string(sea_query::MysqlQueryBuilder);
+        sqlx::query(sqlx::AssertSqlSafe(statment.as_str()))
+            .execute(connection)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(
+        &self,
+        connection: &mut sqlx::MySqlConnection,
+    ) -> Result<(), sqlx_migrator::Error> {
+        let statment = drop_statement().to_string(sea_query::MysqlQueryBuilder);
+        sqlx::query(sqlx::AssertSqlSafe(statment.as_str()))
+            .execute(connection)
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait::async_trait]
+impl sqlx_migrator::Operation<sqlx::Postgres> for Operation {
+    async fn up(&self, connection: &mut sqlx::PgConnection) -> Result<(), sqlx_migrator::Error> {
+        let statment = up_statement().to_string(sea_query::PostgresQueryBuilder);
+        sqlx::query(sqlx::AssertSqlSafe(statment.as_str()))
+            .execute(connection)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, connection: &mut sqlx::PgConnection) -> Result<(), sqlx_migrator::Error> {
+        let statment = drop_statement().to_string(sea_query::PostgresQueryBuilder);
+        sqlx::query(sqlx::AssertSqlSafe(statment.as_str()))
+            .execute(connection)
+            .await?;
+
+        Ok(())
+    }
+}

--- a/evento-sql-migrator/src/m0005/event/mod.rs
+++ b/evento-sql-migrator/src/m0005/event/mod.rs
@@ -1,0 +1,1 @@
+pub mod create_type_cursor_idx;

--- a/evento-sql-migrator/src/m0005/mod.rs
+++ b/evento-sql-migrator/src/m0005/mod.rs
@@ -1,0 +1,64 @@
+//! Migration adding a leading-cursor index for no-routing-key subscription scans.
+//!
+//! The m0004 index `idx_event_type_routing_cursor` places `routing_key` between
+//! `aggregator_type` and the cursor/sort columns, so it only helps subscriptions
+//! that constrain `routing_key`. A subscription reading with `.all()` has no
+//! `routing_key` predicate, so the planner can only use that index up to
+//! `aggregator_type=?` — the `timestamp` range becomes unreachable, forcing a full
+//! scan of every matching row plus an external sort on every poll.
+//!
+//! This migration adds a second, complementary index whose cursor columns come
+//! immediately after `aggregator_type`, letting the `timestamp > ?` cursor bound
+//! push into the index seek so a caught-up poll returns without a scan or sort.
+
+mod event;
+
+use sqlx_migrator::vec_box;
+
+/// Migration that adds a leading-cursor index for `.all()` subscription scans.
+///
+/// ## Changes
+///
+/// - Creates `idx_event_type_cursor` on
+///   `(aggregator_type, timestamp, timestamp_subsec, version, id)`.
+///
+/// ## Notes
+///
+/// - This is additive: `idx_event_type_routing_cursor` (m0004) is kept, since it
+///   still serves subscriptions that filter by `routing_key`.
+/// - The trailing `id` is included so the index fully covers the keyset tiebreaker
+///   (`id` is the final `ORDER BY` / cursor column), avoiding any residual sort.
+/// - It also lets the `latest_timestamp()` query (`MAX(timestamp)` over the same
+///   filter) read the index tail.
+///
+/// ## Dependencies
+///
+/// This migration depends on [`M0004`](crate::M0004).
+pub struct M0005;
+
+#[cfg(feature = "sqlite")]
+sqlx_migrator::sqlite_migration!(
+    M0005,
+    "main",
+    "m0005",
+    vec_box![crate::M0004],
+    vec_box![event::create_type_cursor_idx::Operation]
+);
+
+#[cfg(feature = "mysql")]
+sqlx_migrator::mysql_migration!(
+    M0005,
+    "main",
+    "m0005",
+    vec_box![crate::M0004],
+    vec_box![event::create_type_cursor_idx::Operation]
+);
+
+#[cfg(feature = "postgres")]
+sqlx_migrator::postgres_migration!(
+    M0005,
+    "main",
+    "m0005",
+    vec_box![crate::M0004],
+    vec_box![event::create_type_cursor_idx::Operation]
+);

--- a/evento-sql/tests/pool.rs
+++ b/evento-sql/tests/pool.rs
@@ -1,7 +1,7 @@
 use evento::{
     cursor::{Args, Order, ReadResult},
     sql::Reader,
-    sql_migrator::{InitMigration, M0002, M0003, M0004},
+    sql_migrator::{InitMigration, M0002, M0003, M0004, M0005},
     Event,
 };
 use evento_test::assert_read_result;
@@ -227,6 +227,7 @@ where
     M0002: sqlx_migrator::Migration<DB>,
     M0003: sqlx_migrator::Migration<DB>,
     M0004: sqlx_migrator::Migration<DB>,
+    M0005: sqlx_migrator::Migration<DB>,
     sqlx_migrator::Migrator<DB>: sqlx_migrator::migrator::DatabaseOperation<DB>,
 {
     install_default_drivers();


### PR DESCRIPTION
## Problem

A production `.all()` subscription (`recipe-query`) logged a **1.2s** slow query on every poll — even when caught up with 0 new rows.

Because `.all()` reads have **no `routing_key` predicate**, m0004's `idx_event_type_routing_cursor (aggregator_type, routing_key, timestamp, timestamp_subsec, version)` is only usable up to `aggregator_type=?` — `routing_key` sits between `aggregator_type` and the cursor/sort columns, so the `timestamp` range is unreachable. SQLite scans every matching row (once per name OR-branch) and does an external `TEMP B-TREE` sort. m0004's own doc even assumes queries come "always with a `routing_key` predicate"; `.all()` violates that.

```
MULTI-INDEX OR
  SEARCH event USING INDEX idx_event_type_routing_cursor (aggregator_type=?)   ← equality only, no range
USE TEMP B-TREE FOR ORDER BY                                                    ← full external sort
```

## Fix

Add migration **m0005** creating `idx_event_type_cursor` on `(aggregator_type, timestamp, timestamp_subsec, version, id)`. The cursor columns come immediately after `aggregator_type`, so the `timestamp > ?` keyset bound pushes into the index seek and a caught-up poll seeks straight past the tail.

Measured on the reporter's DB (~29k events, tail cursor → 0 rows): **0.358s → 0.0008s (~450×)**.

- Trailing `id` fully covers the ORDER BY / keyset tiebreaker → no residual sort.
- Also speeds up `latest_timestamp()` (`MAX(timestamp)` over the same filter) by reading the index tail.
- **Additive**: `idx_event_type_routing_cursor` is kept for routing-key-scoped subscriptions.
- No query-builder changes needed — evento uses no index hints, so the planner picks it up automatically.

## Changes

- `evento-sql-migrator/src/m0005/**` — new migration (sqlite/mysql/postgres), modeled on m0004.
- `evento-sql-migrator/src/lib.rs` — register `M0005` (module, re-export, both `new()` variants, doc list).
- `evento-sql/tests/pool.rs` — add `M0005` bound to the generic `create_pool` harness.

## Verification

- `cargo build -p evento-sql-migrator` (default) ✓
- `cargo build -p evento-sql-migrator --no-default-features --features postgres` ✓
- `cargo test -p evento-sql --test sqlite --features sqlite` → **40 passed** (full m0001→m0005 chain applies; subscription reads incl. `.all()` paths work) ✓

## Deploy note

This builds an index on the (large) `event` table and briefly holds a write lock during migration — apply in a low-traffic window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)