### PR TITLE
fix(projection)!: co-key secondary aggregates in load and subscription mode

### DIFF
--- a/evento-core/src/projection.rs
+++ b/evento-core/src/projection.rs
@@ -462,22 +462,25 @@ impl<E: Executor, P: Snapshot<E> + Default + 'static> Projection<E, P> {
         let read_aggregators = self
             .handlers
             .values()
-            .map(|h| match aggregators.get(h.aggregate_type()) {
-                Some(id) => EventFilter {
+            .map(|h| {
+                // Scope each handler to one id: the id registered via
+                // `.aggregate::<S>(id)` when present, otherwise auto-key to the
+                // primary id (co-keyed by default). In subscription mode the
+                // primary id is the event's aggregate id, so co-keyed secondary
+                // aggregates are scoped correctly with no explicit registration.
+                let aggregate_id = aggregators
+                    .get(h.aggregate_type())
+                    .map(ToOwned::to_owned)
+                    .unwrap_or_else(|| id.to_owned());
+
+                EventFilter {
                     aggregate_type: h.aggregate_type().to_owned(),
-                    aggregate_id: Some(id.to_owned()),
+                    aggregate_id: Some(aggregate_id),
                     name: if self.safety_disabled {
                         Some(h.event_name().to_owned())
                     } else {
                         None
                     },
-                },
-                _ => {
-                    if self.safety_disabled {
-                        EventFilter::by_event(h.aggregate_type(), h.event_name())
-                    } else {
-                        EventFilter::by_type(h.aggregate_type())
-                    }
                 }
             })
             .collect::<Vec<_>>();
@@ -528,6 +531,11 @@ impl<E: Executor, P: Snapshot<E> + Default + 'static> Projection<E, P> {
 /// Created via [`Projection::load`]. Allows registering related aggregates
 /// whose events also feed this projection, then [`LoadBuilder::execute`] runs
 /// the load.
+///
+/// A handler's aggregate type defaults to **co-keyed** with the loaded id: its
+/// events are read scoped to that same id. Register a secondary aggregate with
+/// [`LoadBuilder::aggregate`] (or [`LoadBuilder::aggregate_raw`]) only when it
+/// uses a different id.
 pub struct LoadBuilder<E: Executor, P: Default + 'static> {
     projection: Projection<E, P>,
     id: String,
@@ -569,6 +577,26 @@ impl<E: Executor, P: Snapshot<E> + Default + 'static> LoadBuilder<E, P> {
 /// Created via [`Projection::subscription`]. On each incoming event, the
 /// subscription loads the affected aggregate id through the projection,
 /// which in turn re-runs handlers and persists the snapshot.
+///
+/// # Multi-aggregate projections (co-keying)
+///
+/// Unlike [`LoadBuilder`], a subscription has no per-call related-aggregate
+/// ids to work with — it only knows the id of the event that woke it. So every
+/// **secondary** aggregate a handler targets (any aggregate type other than the
+/// primary passed to [`Projection::new`]) is treated as **co-keyed**: assumed
+/// to share the primary aggregate's id. Concretely:
+///
+/// - The worker also wakes on secondary-aggregate events (not just primary
+///   ones), so a change to a co-keyed aggregate re-projects the row.
+/// - When reloading, each secondary aggregate is scoped to the woken
+///   `event.aggregate_id`, exactly as if you had called
+///   `.aggregate::<Secondary>(event.aggregate_id)` in load mode.
+///
+/// **Limitation:** if a secondary aggregate does *not* share the primary's id,
+/// its events won't be found under that id and won't be applied by the
+/// subscription. For that case, rebuild on demand with
+/// [`LoadBuilder::aggregate`] (which takes the real secondary id) or drive a
+/// manual [`SubscriptionBuilder`] that resolves the mapping itself.
 pub struct ProjectionSubscription<E: Executor, P: Default + 'static> {
     projection: Projection<E, P>,
     key: String,
@@ -634,6 +662,22 @@ where
     ///
     /// Returns a [`Subscription`] handle that can be used for graceful shutdown.
     pub async fn start(self, executor: &E) -> anyhow::Result<Subscription> {
+        self.into_builder().start(executor).await
+    }
+
+    /// Processes every currently-available event once, then returns.
+    ///
+    /// Runs a single drain pass without spawning a background worker. Useful
+    /// for tests and one-shot rebuilds; [`start`](Self::start) is the normal
+    /// entry point for a long-running subscription.
+    pub async fn run_once(self, executor: &E) -> anyhow::Result<()> {
+        let mut builder = self.into_builder();
+        builder.run_once(executor).await
+    }
+
+    /// Assembles the underlying [`SubscriptionBuilder`] shared by
+    /// [`start`](Self::start) and [`run_once`](Self::run_once).
+    fn into_builder(self) -> SubscriptionBuilder<E> {
         let ProjectionSubscription {
             projection,
             key,
@@ -644,23 +688,24 @@ where
             continue_on_error,
         } = self;
 
-        let aggregate_type: &'static str = projection.aggregate_type;
         let tombstone = projection.tombstone;
-        // Capture the event names registered for the primary aggregator type.
-        // Each event_name is &'static str because Handler::event_name returns
-        // &'static str (always derived from the `#[evento::handler]` macro).
-        // Drop any handler that collides with the tombstone — that event is
-        // routed to ProjectionTombstoneHandler instead.
-        let event_names: Vec<&'static str> = projection
+
+        // One auto-handler per registered event, across the primary *and* any
+        // co-keyed secondary aggregate, so the worker wakes on secondary events
+        // too (not just the primary's). Each event_name is &'static str
+        // (Handler::event_name always derives from the `#[evento::handler]`
+        // macro). Drop any handler that collides with the tombstone — that event
+        // routes to ProjectionTombstoneHandler. Secondary aggregates are scoped
+        // by `load_aggregator`, which auto-keys them to the event's id.
+        let specs: Vec<(&'static str, &'static str)> = projection
             .handlers
             .values()
-            .filter(|h| h.aggregate_type() == aggregate_type)
             .filter(|h| {
                 tombstone
                     .map(|(t, e)| !(h.aggregate_type() == t && h.event_name() == e))
                     .unwrap_or(true)
             })
-            .map(|h| h.event_name())
+            .map(|h| (h.aggregate_type(), h.event_name()))
             .collect();
 
         let projection = Arc::new(projection);
@@ -674,7 +719,7 @@ where
         builder = builder.chunk_size(chunk_size);
         builder = match retry {
             Some(n) => builder.retry(n),
-            None => builder,
+            None => builder.no_retry(),
         };
         if let Some(d) = delay {
             builder = builder.delay(d);
@@ -683,10 +728,10 @@ where
             builder = builder.continue_on_error();
         }
 
-        for event_name in event_names {
+        for (spec_type, event_name) in specs {
             builder = builder.handler(ProjectionAutoHandler::<E, P> {
                 projection: projection.clone(),
-                aggregate_type,
+                aggregate_type: spec_type,
                 event_name,
                 _marker: PhantomData,
             });
@@ -701,11 +746,7 @@ where
             });
         }
 
-        if retry.is_none() {
-            builder.no_retry().start(executor).await
-        } else {
-            builder.start(executor).await
-        }
+        builder
     }
 }
 
@@ -727,6 +768,8 @@ where
         event: &'a crate::Event,
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send + 'a>> {
         Box::pin(async move {
+            // `load_aggregator` auto-keys every co-keyed secondary aggregate to
+            // this event's id, so no extra aggregators need to be supplied here.
             self.projection
                 .load_aggregator(context.executor, &event.aggregate_id, &HashMap::new())
                 .await?;

--- a/evento-fjall/tests/fjall.rs
+++ b/evento-fjall/tests/fjall.rs
@@ -78,6 +78,18 @@ async fn fjall_subscribe_multiple_aggregator() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn fjall_subscribe_co_keyed_aggregator() -> anyhow::Result<()> {
+    let (executor, _temp_dir) = create_fjall_executor("subscribe_co_keyed_aggregator")?;
+    evento_test::subscribe_co_keyed_aggregator(&executor).await
+}
+
+#[tokio::test]
+async fn fjall_load_co_keyed_aggregator() -> anyhow::Result<()> {
+    let (executor, _temp_dir) = create_fjall_executor("load_co_keyed_aggregator")?;
+    evento_test::load_co_keyed_aggregator(&executor).await
+}
+
+#[tokio::test]
 async fn fjall_subscribe_routing_key_multiple_aggregator() -> anyhow::Result<()> {
     let (executor, _temp_dir) = create_fjall_executor("subscribe_routing_key_multiple_aggregator")?;
     evento_test::subscribe_routing_key_multiple_aggregator(&executor).await

--- a/evento-sql/tests/mysql.rs
+++ b/evento-sql/tests/mysql.rs
@@ -85,6 +85,20 @@ async fn mysql_subscribe_multiple_aggregator() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn mysql_subscribe_co_keyed_aggregator() -> anyhow::Result<()> {
+    let pool = create_mysql_pool("subscribe_co_keyed_aggregator").await?;
+
+    evento_test::subscribe_co_keyed_aggregator::<Sql<sqlx::MySql>>(&pool.into()).await
+}
+
+#[tokio::test]
+async fn mysql_load_co_keyed_aggregator() -> anyhow::Result<()> {
+    let pool = create_mysql_pool("load_co_keyed_aggregator").await?;
+
+    evento_test::load_co_keyed_aggregator::<Sql<sqlx::MySql>>(&pool.into()).await
+}
+
+#[tokio::test]
 async fn mysql_subscribe_routing_key_multiple_aggregator() -> anyhow::Result<()> {
     let pool = create_mysql_pool("subscribe_routing_key_multiple_aggregator").await?;
 

--- a/evento-sql/tests/postgres.rs
+++ b/evento-sql/tests/postgres.rs
@@ -74,6 +74,20 @@ async fn postgres_subscribe_multiple_aggregator() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn postgres_subscribe_co_keyed_aggregator() -> anyhow::Result<()> {
+    let pool = create_postgres_pool("subscribe_co_keyed_aggregator").await?;
+
+    evento_test::subscribe_co_keyed_aggregator::<Sql<sqlx::Postgres>>(&pool.into()).await
+}
+
+#[tokio::test]
+async fn postgres_load_co_keyed_aggregator() -> anyhow::Result<()> {
+    let pool = create_postgres_pool("load_co_keyed_aggregator").await?;
+
+    evento_test::load_co_keyed_aggregator::<Sql<sqlx::Postgres>>(&pool.into()).await
+}
+
+#[tokio::test]
 async fn postgres_subscribe_routing_key_multiple_aggregator() -> anyhow::Result<()> {
     let pool = create_postgres_pool("subscribe_routing_key_multiple_aggregator").await?;
 

--- a/evento-sql/tests/sqlite.rs
+++ b/evento-sql/tests/sqlite.rs
@@ -90,6 +90,20 @@ async fn sqlite_subscribe_multiple_aggregator() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+async fn sqlite_subscribe_co_keyed_aggregator() -> anyhow::Result<()> {
+    let pool = create_sqlite_pool("subscribe_co_keyed_aggregator").await?;
+
+    evento_test::subscribe_co_keyed_aggregator::<Sql<sqlx::Sqlite>>(&pool.into()).await
+}
+
+#[tokio::test]
+async fn sqlite_load_co_keyed_aggregator() -> anyhow::Result<()> {
+    let pool = create_sqlite_pool("load_co_keyed_aggregator").await?;
+
+    evento_test::load_co_keyed_aggregator::<Sql<sqlx::Sqlite>>(&pool.into()).await
+}
+
+#[tokio::test]
 async fn sqlite_subscribe_routing_key_multiple_aggregator() -> anyhow::Result<()> {
     let pool = create_sqlite_pool("subscribe_routing_key_multiple_aggregator").await?;
 
@@ -193,6 +207,20 @@ async fn rw_sqlite_subscribe_multiple_aggregator() -> anyhow::Result<()> {
     let pool = create_rw_sqlite_pool("subscribe_multiple_aggregator").await?;
 
     evento_test::subscribe_multiple_aggregator::<RwSqlite>(&rw_from_pools(pool)).await
+}
+
+#[tokio::test]
+async fn rw_sqlite_subscribe_co_keyed_aggregator() -> anyhow::Result<()> {
+    let pool = create_rw_sqlite_pool("subscribe_co_keyed_aggregator").await?;
+
+    evento_test::subscribe_co_keyed_aggregator::<RwSqlite>(&rw_from_pools(pool)).await
+}
+
+#[tokio::test]
+async fn rw_sqlite_load_co_keyed_aggregator() -> anyhow::Result<()> {
+    let pool = create_rw_sqlite_pool("load_co_keyed_aggregator").await?;
+
+    evento_test::load_co_keyed_aggregator::<RwSqlite>(&rw_from_pools(pool)).await
 }
 
 #[tokio::test]

--- a/evento-test/src/lib.rs
+++ b/evento-test/src/lib.rs
@@ -1091,6 +1091,182 @@ pub async fn subscribe_multiple_aggregator<E: Executor + Clone>(
     Ok(())
 }
 
+/// A `Projection` whose handlers span the primary (`BankAccount`) and a
+/// **co-keyed** secondary (`Owner`) aggregate — one whose events share the
+/// primary's id. In subscription mode the worker must wake on the secondary's
+/// events and scope them to `event.aggregate_id`; without that, an `Owner`
+/// handler would read every `NameChanged` in the store and smear the last one
+/// into every row.
+mod co_keyed {
+    use std::{collections::HashMap, sync::RwLock};
+
+    use bank::aggregator::{AccountOpened, BankAccount, NameChanged};
+    use evento::{metadata::Event, projection::Projection, Executor};
+    use once_cell::sync::Lazy;
+
+    // aggregate_id -> owner_name, written by the Owner handler as a subscription
+    // applies co-keyed `NameChanged` events. Keyed by the unique account id so
+    // concurrent backend tests don't collide.
+    pub static ROWS: Lazy<RwLock<HashMap<String, String>>> = Lazy::new(Default::default);
+
+    #[evento::projection(bitcode::Encode, bitcode::Decode)]
+    pub struct View {
+        pub id: String,
+        pub owner_name: String,
+    }
+
+    // Sets identity only — deliberately does not touch `owner_name`, so the
+    // co-keyed `NameChanged` is its sole writer and the result is independent of
+    // the order the two co-keyed events (same id, both version 1) replay in.
+    #[evento::handler]
+    async fn on_account_opened(event: Event<AccountOpened>, view: &mut View) -> anyhow::Result<()> {
+        view.id = event.aggregate_id.to_owned();
+        Ok(())
+    }
+
+    #[evento::handler]
+    async fn on_owner_name_changed(
+        event: Event<NameChanged>,
+        view: &mut View,
+    ) -> anyhow::Result<()> {
+        view.owner_name = event.data.value.to_owned();
+        ROWS.write()
+            .unwrap()
+            .insert(event.aggregate_id.to_owned(), event.data.value);
+        Ok(())
+    }
+
+    pub fn projection<E: Executor>() -> Projection<E, View> {
+        Projection::new::<BankAccount>()
+            .handler(on_account_opened())
+            .handler(on_owner_name_changed())
+    }
+}
+
+/// A projection subscription over a co-keyed secondary aggregate must scope that
+/// aggregate to each event's id — not read every instance of its type.
+pub async fn subscribe_co_keyed_aggregator<E: Executor + Clone>(
+    executor: &E,
+) -> anyhow::Result<()> {
+    let cmd = bank::Command(executor.clone());
+
+    // Two accounts, each with an `Owner` stream co-keyed under the account's own
+    // id (append the Owner `NameChanged` to the account id). Versions are tracked
+    // per (aggregate_type, id), so this is independent of the account's version.
+    let account_a = cmd
+        .open_account(OpenAccount {
+            owner_id: Ulid::new().to_string(),
+            owner_name: "A-at-open".to_owned(),
+            account_type: AccountType::Checking,
+            currency: "USD".to_owned(),
+            initial_balance: 1000,
+        })
+        .await?;
+    evento::append(&account_a)
+        .event(&NameChanged {
+            value: "Alice".to_owned(),
+        })
+        .commit(executor)
+        .await?;
+
+    let account_b = cmd
+        .open_account(OpenAccount {
+            owner_id: Ulid::new().to_string(),
+            owner_name: "B-at-open".to_owned(),
+            account_type: AccountType::Checking,
+            currency: "USD".to_owned(),
+            initial_balance: 2000,
+        })
+        .await?;
+    evento::append(&account_b)
+        .event(&NameChanged {
+            value: "Bob".to_owned(),
+        })
+        .commit(executor)
+        .await?;
+
+    // Co-keying is automatic: no `.aggregate::<Owner>()` call needed.
+    co_keyed::projection()
+        .subscription("co-keyed")
+        .all()
+        .no_retry()
+        .run_once(executor)
+        .await?;
+
+    // Copy the values out and drop the lock before asserting, so a failing
+    // assert can't poison the shared lock for other concurrent tests.
+    let (a, b) = {
+        let rows = co_keyed::ROWS.read().unwrap();
+        (rows.get(&account_a).cloned(), rows.get(&account_b).cloned())
+    };
+    assert_eq!(
+        a.as_deref(),
+        Some("Alice"),
+        "account A must get its own co-keyed owner name"
+    );
+    assert_eq!(
+        b.as_deref(),
+        Some("Bob"),
+        "co-keyed Owner must be scoped per id, not smeared across every account"
+    );
+
+    Ok(())
+}
+
+/// `.load()` auto-keys a secondary aggregate to the loaded id when it is not
+/// registered with `.aggregate::<S>(id)` — scoping its events to that id rather
+/// than reading every instance of the type.
+pub async fn load_co_keyed_aggregator<E: Executor + Clone>(executor: &E) -> anyhow::Result<()> {
+    let cmd = bank::Command(executor.clone());
+
+    let account_a = cmd
+        .open_account(OpenAccount {
+            owner_id: Ulid::new().to_string(),
+            owner_name: "A-at-open".to_owned(),
+            account_type: AccountType::Checking,
+            currency: "USD".to_owned(),
+            initial_balance: 1000,
+        })
+        .await?;
+    evento::append(&account_a)
+        .event(&NameChanged {
+            value: "Alice".to_owned(),
+        })
+        .commit(executor)
+        .await?;
+
+    // A second account with its own co-keyed Owner rename — it must not leak
+    // into account A's view.
+    let account_b = cmd
+        .open_account(OpenAccount {
+            owner_id: Ulid::new().to_string(),
+            owner_name: "B-at-open".to_owned(),
+            account_type: AccountType::Checking,
+            currency: "USD".to_owned(),
+            initial_balance: 2000,
+        })
+        .await?;
+    evento::append(&account_b)
+        .event(&NameChanged {
+            value: "Bob".to_owned(),
+        })
+        .commit(executor)
+        .await?;
+
+    // No `.aggregate::<Owner>(..)`: the Owner handler auto-keys to `account_a`.
+    let view = co_keyed::projection()
+        .load(&account_a)
+        .execute(executor)
+        .await?
+        .expect("account A view");
+    assert_eq!(
+        view.owner_name, "Alice",
+        "unregistered secondary must auto-key to the loaded id, not read every instance"
+    );
+
+    Ok(())
+}
+
 pub async fn subscribe_routing_key_multiple_aggregator<E: Executor + Clone>(
     executor: &E,
 ) -> anyhow::Result<()> {


### PR DESCRIPTION
## Problem

A `Projection` whose handlers span more than the primary aggregate was mishandled outside of explicit load registration:

- **Subscription mode** — the worker only woke on **primary**-aggregate events and rebuilt with an empty aggregator map. A secondary handler (e.g. an `Owner`/`Subscription` co-keyed with the primary) took the `by_event`/`by_type` fallback and read **every** event of its type in the whole store, applying them in cursor order and smearing the last value into every row rebuilt afterwards.
- **Load mode** — an unregistered secondary aggregate fell back to the same unscoped read.

This was real and previously untested: the only projection-subscription in the repo (`examples/bank-axum-accord`) hit it via its `Owner` handler, and no test exercised `Projection::subscription()` with a secondary aggregate.

## Fix

Unify co-keying in one place — `load_aggregator`. A handler whose aggregate type is **not** explicitly registered now **auto-keys to the loaded id** (the event id in subscription mode), i.e. it is treated as co-keyed with the primary and scoped to that single id.

- `.load(id)` — register a secondary with `.aggregate::<S>(id)` only when it uses a **different** id; otherwise it co-keys automatically. No more forced registration, no more unscoped smear.
- `.subscription(...)` — the worker now also wakes on secondary-aggregate events, and each reload co-keys secondaries to `event.aggregate_id`. The previously-needed `secondary_types` plumbing is gone; `ProjectionAutoHandler` just relies on the auto-key.

`context.aggregate::<S>()` is unchanged (still panics for unregistered types) — no handler in the repo relies on it, so its safety is preserved.

### Limitation (documented)

A secondary aggregate that does **not** share the primary's id (e.g. bank's `Owner` with a separate `owner_id`) can't be co-keyed by a subscription — use load mode with `.aggregate::<S>(other_id)` or a manual `SubscriptionBuilder`. The accord example keeps building; its non-co-keyed `Owner` renames simply aren't reflected in the RAM cache (they are via the load path).

## Tests

Added to the shared `evento-test` suite and wired into **sqlite, rw_sqlite, postgres, mysql, fjall**:

- `subscribe_co_keyed_aggregator` — two accounts, each with an `Owner` `NameChanged` co-keyed under its own id; asserts each row gets its **own** name ("Alice"/"Bob"), not a smeared value.
- `load_co_keyed_aggregator` — loads one account **without** registering `Owner`; asserts the auto-key scopes to the loaded id (reads "Alice", not the other account's "Bob").

Handlers are written to be replay-order-independent (the co-keyed events share id + version), so the tests are stable across backends.

## Verification

- sqlite (44) + rw variants, fjall (25), core (26), doc (1) — all pass; co-keyed tests stable across repeated runs.
- postgres/mysql test targets compile (need live DBs to run).
- `cargo clippy --all-features -- -D warnings`, `cargo fmt`, `cargo machete` — clean.

## BREAKING CHANGE

An unregistered secondary-aggregate handler now reads events scoped to the loaded/event id instead of every instance of that type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)