### PR TITLE
fix(accord): fall back to slow quorum when preaccept misses the fast window

### DIFF
--- a/evento-accord/src/node.rs
+++ b/evento-accord/src/node.rs
@@ -1318,7 +1318,7 @@ impl Node {
                 .filter(|(from, _)| p.electorate.contains(from))
                 .count()
         };
-        let pre = self
+        let mut pre = self
             .collect_by_shard_tagged(
                 &mut rx,
                 &plans,
@@ -1332,6 +1332,35 @@ impl Node {
                 },
             )
             .await;
+        // The fast-path window may close before a slow quorum has witnessed the
+        // txn (e.g. cold connections at startup, where the first handshake
+        // outlasts `fast_timeout`). Keep collecting up to the slow-path budget
+        // so a simple majority can still carry the write down the slow path.
+        if plans.iter().any(|p| pre[&p.shard].len() < p.slow_q) {
+            let remaining: HashMap<ShardId, usize> = plans
+                .iter()
+                .map(|p| (p.shard, p.slow_q.saturating_sub(pre[&p.shard].len())))
+                .collect();
+            let more = self
+                .collect_by_shard_tagged(
+                    &mut rx,
+                    &plans,
+                    |p, got| got.len() >= remaining[&p.shard],
+                    Self::after(self.settings.collect_timeout),
+                    |m| match m {
+                        Message::PreAcceptOk {
+                            execute_at, deps, ..
+                        } => Some((execute_at, deps)),
+                        _ => None,
+                    },
+                )
+                .await;
+            for (shard, mut items) in more {
+                if let Some(bucket) = pre.get_mut(&shard) {
+                    bucket.append(&mut items);
+                }
+            }
+        }
         for plan in &plans {
             if pre[&plan.shard].len() < plan.slow_q {
                 self.deregister(txn);


### PR DESCRIPTION
## Problem

The mTLS/TCP cluster tests (`replicates_over_per_node_mutual_tls`, `resolves_a_conflict_over_per_node_mutual_tls`, and their TCP siblings) fail intermittently in CI with:

> write failed over mTLS: preaccept quorum not reached for shard 0

**Root cause.** In `Node::coordinate` (`evento-accord/src/node.rs`), the PreAccept phase collected responses for only `fast_timeout` (50ms) and then hard-failed if fewer than `slow_q` (2 of 3) responses had arrived. The generous 5s `collect_timeout` is used only by the later Accept/Read/Apply phases, which are unreachable when PreAccept can't gather a slow quorum in 50ms. On the **first** write after cluster start, peer connections are cold — the transport connects lazily and must complete a TCP connect + mTLS handshake per peer. Under CI load at least one handshake exceeds 50ms, so the write bails.

## Fix

Keep the 50ms fast-path early-exit unchanged, but when a fast quorum is **not** reached in that window, continue collecting up to the existing `collect_timeout` (5s) so a simple majority can still witness the txn and carry the write down the slow path — exactly what the Accord protocol expects. This also fixes cold-start writes in production, not just the tests.

Correctness notes:
- The second collect drains only *new* arrivals from the response channel, so a node is never double-counted; each shard's target is its exact shortfall.
- `all_fast` is still computed from the merged responses, so a late fast quorum correctly falls through to the slow (Accept) path — a latency difference, never a safety one.
- When a fast quorum lands within 50ms the guard is false and the second collect is skipped, so fast-path latency is unchanged.

## Verification

- `cargo build -p evento-accord` — clean
- `cargo test -p evento-accord` — full suite green (no regression in fast-path/conflict/recovery)
- Looped `replicates_over_per_node_mutual_tls` 25× — all pass
- `cargo clippy -p evento-accord --all-targets` — no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)